### PR TITLE
Feature/less stupid authentication

### DIFF
--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -5,8 +5,6 @@ class CoreFilesController < ApplicationController
   skip_before_filter :load_asset, :load_datastream, :authorize_download!
   before_filter :load_core_file, :only => %i(show_teibp show_tapas_generic)
 
-  skip_before_filter :authenticate_api_request, :only => [:show_teibp, :show_tapas_generic]
-
   def show_teibp 
     render_asset(@core_file.teibp)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,8 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  def api_key
-    @api_key ||= BCrypt::Password.new(self.encrypted_api_key)
-  end
-
   def api_key=(api_key)
-    @api_key = BCrypt::Password.create(api_key, cost: 6)
+    @api_key = Digest::SHA512.hexdigest api_key
     self.encrypted_api_key = @api_key
   end
 
@@ -28,7 +24,7 @@ class User < ActiveRecord::Base
     def generate_api_key
       key = Devise.friendly_token
 
-      @api_key = BCrypt::Password.create(key, cost: 6) 
+      @api_key = Digest::SHA512.hexdigest key
 
       if User.where(:encrypted_api_key => @api_key)
         generate_api_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   attr_accessible :email, :password, :password_confirmation if Rails::VERSION::MAJOR < 4
-# Connects this user object to Blacklights Bookmarks. 
+  # Connects this user object to Blacklights Bookmarks. 
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,23 +1,29 @@
 require 'spec_helper'
 
 describe CollectionsController do
-  let(:user) { FactoryGirl.create(:user) } 
-  let(:params) { { email: user.email, token: "test_api_key" } } 
-
   it_should_behave_like "an API enabled controller"
+
+  before(:each) do 
+    # Instatiate the test user before we try to use his credentials
+    FactoryGirl.create(:user)
+
+    t = ActionController::HttpAuthentication::Token.
+      encode_credentials('test_api_key')
+    request.env['HTTP_AUTHORIZATION'] = t
+  end
 
   describe "DELETE destroy" do 
     after(:each) { ActiveFedora::Base.delete_all }
 
     it "422s for nonexistant dids" do 
-      delete :destroy, params.merge(:did => "not a real did") 
+      delete :destroy, { :did => "not a real did" }
       expect(response.status).to eq 422
     end
 
     it "422s for dids that don't belong to a Collection" do 
       begin
         community = Community.create(:did => "115", :depositor => "test")
-        delete :destroy, params.merge(:did => community.did)
+        delete :destroy, { :did => community.did }
         expect(response.status).to eq 422
       ensure
         community.delete if community.persisted?
@@ -26,7 +32,7 @@ describe CollectionsController do
 
     it "200s for dids that belong to a Collection and removes the resource" do 
       collection = Collection.create(:did => "938401", :depositor => "test")
-      delete :destroy, params.merge(:did => collection.did)
+      delete :destroy, { :did => collection.did }
       expect(response.status).to eq 200
       expect(Collection.find_by_did collection.did).to be nil 
     end
@@ -36,12 +42,14 @@ describe CollectionsController do
     after(:all) { ActiveFedora::Base.delete_all } 
 
     it "403s for unauthorized requests" do 
-      post :upsert, params.except(:token)
+      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::
+        Token.encode_credentials('not_an_api_key')
+      post :upsert
       expect(response.status).to eq 403
     end
 
     it "422s for invalid requests" do 
-      post :upsert, params 
+      post :upsert, {}
       expect(response.status).to eq 422 
     end
 
@@ -53,7 +61,7 @@ describe CollectionsController do
         project_did: "invalid", 
         description: "This is a test collection",
         depositor: "101" }
-      post_params = post_params.merge params
+
       post :upsert, post_params
 
       expect(response.status).to eq 202

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,16 +1,9 @@
 require 'spec_helper'
 
 describe CollectionsController do
+  include ValidAuthToken
+
   it_should_behave_like "an API enabled controller"
-
-  before(:each) do 
-    # Instatiate the test user before we try to use his credentials
-    FactoryGirl.create(:user)
-
-    t = ActionController::HttpAuthentication::Token.
-      encode_credentials('test_api_key')
-    request.env['HTTP_AUTHORIZATION'] = t
-  end
 
   describe "DELETE destroy" do 
     after(:each) { ActiveFedora::Base.delete_all }

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -35,8 +35,7 @@ describe CollectionsController do
     after(:all) { ActiveFedora::Base.delete_all } 
 
     it "403s for unauthorized requests" do 
-      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::
-        Token.encode_credentials('not_an_api_key')
+      set_auth_token('bupkes')
       post :upsert
       expect(response.status).to eq 403
     end

--- a/spec/controllers/communities_controller_spec.rb
+++ b/spec/controllers/communities_controller_spec.rb
@@ -1,14 +1,7 @@
 require 'spec_helper'
 
 describe CommunitiesController do
-  
-  before(:each) do 
-    FactoryGirl.create(:user)
-
-    t = ActionController::HttpAuthentication::Token.
-      encode_credentials('test_api_key') 
-    request.env['HTTP_AUTHORIZATION'] = t
-  end
+  include ValidAuthToken
 
   describe "#DELETE destroy" do 
     after(:each) { ActiveFedora::Base.delete_all }

--- a/spec/controllers/core_files_controller_spec.rb
+++ b/spec/controllers/core_files_controller_spec.rb
@@ -2,15 +2,7 @@ require 'spec_helper'
 
 describe CoreFilesController do
   include FileHelpers
-
-  before(:each) do 
-    # Instatiate the test user before we try to use his credentials 
-    FactoryGirl.create(:user) 
-
-    t = ActionController::HttpAuthentication::Token.
-      encode_credentials('test_api_key')
-    request.env['HTTP_AUTHORIZATION'] = t 
-  end
+  include ValidAuthToken
 
   def test_file(fname)
     pth = Rails.root.join("spec", "fixtures", "files", fname)

--- a/spec/controllers/core_files_controller_spec.rb
+++ b/spec/controllers/core_files_controller_spec.rb
@@ -3,8 +3,14 @@ require 'spec_helper'
 describe CoreFilesController do
   include FileHelpers
 
-  let (:user) { FactoryGirl.create(:user) }
-  let(:params) { { email: user.email, token: "test_api_key" } } 
+  before(:each) do 
+    # Instatiate the test user before we try to use his credentials 
+    FactoryGirl.create(:user) 
+
+    t = ActionController::HttpAuthentication::Token.
+      encode_credentials('test_api_key')
+    request.env['HTTP_AUTHORIZATION'] = t 
+  end
 
   def test_file(fname)
     pth = Rails.root.join("spec", "fixtures", "files", fname)
@@ -16,19 +22,19 @@ describe CoreFilesController do
     after(:each) { ActiveFedora::Base.delete_all }
 
     it "422s for nonexistant dids" do 
-      delete :destroy, params.merge(:did => "not a real did") 
+      delete :destroy, { :did => "not a real did" }
       expect(response.status).to eq 422
     end
 
     it "422s for dids that don't belong to a CoreFile" do 
       community = Community.create(:did => "115", :depositor => "test")
-      delete :destroy, params.merge(:did => community.did)
+      delete :destroy, { :did => community.did }
       expect(response.status).to eq 422
     end
 
     it "200s for dids that belong to a CoreFile and removes the resource" do 
       core = CoreFile.create(:did => "78382", :depositor => "test")
-      delete :destroy, params.merge(:did => core.did)
+      delete :destroy, { :did => core.did }
       expect(response.status).to eq 200
       expect(CoreFile.find_by_did core.did).to be nil 
     end
@@ -48,7 +54,7 @@ describe CoreFilesController do
 
     it "returns a 202 and creates the desired file on a valid request." do 
       Resque.inline = true
-      post :upsert, params.merge(post_defaults)
+      post :upsert, post_defaults
 
       expect(response.status).to eq 202
 

--- a/spec/shared/api_accessible_spec.rb
+++ b/spec/shared/api_accessible_spec.rb
@@ -5,25 +5,17 @@ shared_examples_for "an API enabled controller" do
 
   describe "authentication" do 
 
-    it "raises a 403 for requests with no attached user" do 
-      post :upsert, { token: "blah" } 
-      expect(response.status).to eq 403
-    end
-
-    it "raises a 403 for requests with no attached token" do 
-      post :upsert, { email: "blah" }
+    it "raises a 403 for requests with no authorization header" do
+      request.env['HTTP_AUTHORIZATION'] = nil
+      post :upsert
       expect(response.status).to eq 403
     end
 
     it "raises a 403 for requests with an invalid token" do 
-      post :upsert, { email: user.email, token: "blurgl" }
+      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::
+        Token.encode_credentials(SecureRandom.hex)
+      post :upsert
       expect(response.status).to eq 403
-    end
-
-    # Don't verify that the action does the right thing, since this request 
-    # is probably still bupkes.  Just verify that it doesn't 403.
-    it "doesn't 403 for requests with valid credentials" do
-      pending "Ensure requests always generate at least a 500 error"
     end
   end
 end

--- a/spec/shared/api_accessible_spec.rb
+++ b/spec/shared/api_accessible_spec.rb
@@ -6,14 +6,13 @@ shared_examples_for "an API enabled controller" do
   describe "authentication" do 
 
     it "raises a 403 for requests with no authorization header" do
-      request.env['HTTP_AUTHORIZATION'] = nil
+      set_auth_token(nil)
       post :upsert
       expect(response.status).to eq 403
     end
 
     it "raises a 403 for requests with an invalid token" do 
-      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::
-        Token.encode_credentials(SecureRandom.hex)
+      set_auth_token('bupkes')
       post :upsert
       expect(response.status).to eq 403
     end

--- a/spec/support/valid_auth_token.rb
+++ b/spec/support/valid_auth_token.rb
@@ -1,0 +1,17 @@
+module ValidAuthToken
+  extend ActiveSupport::Concern
+
+  included do 
+    before(:each) { ensure_valid_login }
+  end
+
+  def ensure_valid_login
+    # Instantiate a valid API user
+    user = FactoryGirl.create(:user)
+
+    # Set the mock request object to have a valid Authorization header
+    t = ActionController::HttpAuthentication::Token.
+      encode_credentials('test_api_key')
+    request.env['HTTP_AUTHORIZATION'] = t
+  end
+end

--- a/spec/support/valid_auth_token.rb
+++ b/spec/support/valid_auth_token.rb
@@ -5,13 +5,15 @@ module ValidAuthToken
     before(:each) { ensure_valid_login }
   end
 
+  def set_auth_token(token)
+    t = ActionController::HttpAuthentication::Token.
+      encode_credentials(token.to_s)
+    request.env['HTTP_AUTHORIZATION'] = t 
+  end
+
   def ensure_valid_login
     # Instantiate a valid API user
     user = FactoryGirl.create(:user)
-
-    # Set the mock request object to have a valid Authorization header
-    t = ActionController::HttpAuthentication::Token.
-      encode_credentials('test_api_key')
-    request.env['HTTP_AUTHORIZATION'] = t
+    set_auth_token 'test_api_key'
   end
 end


### PR DESCRIPTION
Transitions us from the arbitrary params based email plus token authentication that I set up (presumably) in a hurry a while ago to token based authentication using the HTTP Authentication header. 