### PR TITLE
Feature/status endpoints

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,17 +10,4 @@ class CollectionsController < ApplicationController
     @response[:message] = "Collection upsert accepted" 
     pretty_json(202) and return 
   end
-
-  def destroy
-    collection = Collection.find_by_did(params[:did]) 
-
-    if collection
-      collection.delete
-      @response[:message] = "Collection successfully deleted."
-      pretty_json(200) and return
-    else
-      @response[:message] = "No collection with did #{params[:did]} found."
-      pretty_json(422) and return 
-    end
-  end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,6 +1,10 @@
 class CommunitiesController < ApplicationController
   include ApiAccessible
 
+  def show
+
+  end
+
   def upsert 
     if params[:thumbnail]
       params[:thumbnail] = create_temp_file(params[:thumbnail])
@@ -12,16 +16,9 @@ class CommunitiesController < ApplicationController
   end 
 
   def destroy
-    community = Community.find_by_did params[:did] 
-
-    if community
-      community.descendents.each { |descendent| descendent.destroy }
-      community.destroy 
-      @response[:message] = "Project successfully destroyed"
-      pretty_json(200) and return
-    else
-      @response[:message] = "Project not found with Drupal ID #{params[:did]}"
-      pretty_json(404) and return
-    end
+    @community.descendents.each { |descendent| descendent.destroy }
+    @community.destroy 
+    @response[:message] = "Project successfully destroyed"
+    pretty_json(200) and return
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,10 +1,6 @@
 class CommunitiesController < ApplicationController
   include ApiAccessible
 
-  def show
-
-  end
-
   def upsert 
     if params[:thumbnail]
       params[:thumbnail] = create_temp_file(params[:thumbnail])

--- a/app/controllers/concerns/api_accessible.rb
+++ b/app/controllers/concerns/api_accessible.rb
@@ -20,8 +20,14 @@ module ApiAccessible
     before_action :validate_upsert, :only => [:upsert]
   end
 
+  def show 
+    resource = get_loaded_resource
+    @response[:message] = resource.as_json
+    pretty_json(200) and return
+  end
+
   def destroy
-    resource = instance_variable_get("@#{controller_path.classify.underscore}")
+    resource = get_loaded_resource
 
     if resource.destroy
       @response[:message] = 'Resource successfully deleted'
@@ -42,6 +48,10 @@ module ApiAccessible
       @response[:message] = "Resource not found"
       pretty_json(404) and return
     end
+  end
+
+  def get_loaded_resource
+    instance_variable_get("@#{controller_path.classify.underscore}")
   end
 
   def authenticate

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -71,15 +71,6 @@ class CoreFilesController < ApplicationController
 
   private
 
-  def load_core_file
-    @core_file = CoreFile.find_by_did(params[:did]) 
-
-    unless @core_file
-      message = 'No record associated with this did was found.'
-      render :text => message, :status => 404
-    end
-  end
-
   def render_content_asset(asset, error_msg)
     if asset && asset.content.content.present?
       render :text => asset.content.content 

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -7,7 +7,6 @@ class CoreFilesController < ApplicationController
   end
 
   skip_before_filter :load_asset, :load_datastream, :authorize_download!
-  before_filter :load_core_file, :only => %i(teibp tapas_generic tei mods)
 
   def teibp 
     e = "Could not find TEI Boilerplate representation of this object.  "\
@@ -67,19 +66,6 @@ class CoreFilesController < ApplicationController
     else
       @response[:message] = "Job processing" 
       pretty_json(202) and return
-    end
-  end
-
-  def destroy
-    core_file = CoreFile.find_by_did(params[:did])
-
-    if core_file
-      core_file.destroy
-      @response[:message] = 'Resource destroyed'
-      pretty_json(200) and return
-    else
-      @response[:message] = 'Could not find requested resource' 
-      pretty_json(422) and return
     end
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -58,6 +58,18 @@ class Collection < CerberusCore::BaseModels::Collection
     @drupal_access_changed = true 
   end
 
+  def as_json
+    fname = (thumbnail_1.label == "File Datastream" ? '' : thumbnail_1.label)
+
+    { :project_did => (community ? community.did : ''),
+      :depositor => depositor,
+      :title => mods.title.first,
+      :access => drupal_access,
+      :thumbnail => fname,
+      :description => mods.abstract.first
+    }
+  end
+
   private 
     def update_core_files
       return true unless @drupal_access_changed 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -30,4 +30,15 @@ class Community < CerberusCore::BaseModels::Community
       return community
     end
   end
+
+  def as_json
+    fname = (thumbnail_1.label == 'File Datastream' ? '' : thumbnail_1.label)
+    { :members => project_members, 
+      :depositor => depositor, 
+      :access => drupal_access, 
+      :thumbnail => fname, 
+      :title => mods.title.first, 
+      :description => mods.abstract.first
+    }
+  end
 end

--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -70,18 +70,29 @@ class CoreFile < CerberusCore::BaseModels::CoreFile
     end
   end
 
-  private
-    def is_ography?
-      CoreFile.all_ography_read_methods.any? do |ography_type| 
-        self.send(ography_type).any?
-      end
-    end  
+  def as_json 
+    tei_name = (canonical_object ? canonical_object.filename : '')
 
-    def calculate_drupal_access
-      if collections.any? { |collection| collection.drupal_access == 'public' }
-        self.drupal_access = 'public'
-      else
-        self.drupal_access = 'private'
-      end
+    { :collection_dids => collections.map(&:did),
+      :tei => tei_name, 
+      :support_files => page_images.map(&:filename),
+      :depositor => depositor,
+      :access => drupal_access,
+    }
+  end
+
+  private
+  def is_ography?
+    CoreFile.all_ography_read_methods.any? do |ography_type| 
+      self.send(ography_type).any?
     end
+  end  
+
+  def calculate_drupal_access
+    if collections.any? { |collection| collection.drupal_access == 'public' }
+      self.drupal_access = 'public'
+    else
+      self.drupal_access = 'private'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,10 +24,12 @@ TapasRails::Application.routes.draw do
   mount Resque::Server, :at => '/resque'
 
   # Communities
+  get 'communities/:did' => 'communities#show'
   post "communities/:did" => "communities#upsert"
   delete "communities/:did" => "communities#destroy"
 
   # Collections
+  get 'collections/:did' => 'collections#show'
   post "collections/:did" => "collections#upsert" 
   delete "collections/:did" => "collections#destroy"
 
@@ -36,6 +38,7 @@ TapasRails::Application.routes.draw do
   get 'files/:did/teibp' => 'core_files#teibp'
   get 'files/:did/tapas_generic' => 'core_files#tapas_generic'
   get 'files/:did/tei' => 'core_files#tei'
+  get 'files/:did' => 'core_files#show'
   post 'files/:did' => 'core_files#upsert'
   delete "files/:did" => "core_files#destroy"
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -9,15 +9,15 @@ describe CollectionsController do
   describe 'DELETE destroy' do 
     after(:each) { ActiveFedora::Base.delete_all }
 
-    it '422s for nonexistant dids' do 
+    it '404s for nonexistant dids' do 
       delete :destroy, { :did => 'not a real did' }
-      expect(response.status).to eq 422
+      expect(response.status).to eq 404
     end
 
-    it '422s for dids that do not belong to a Collection' do 
+    it '404s for dids that do not belong to a Collection' do 
       community = FactoryGirl.create :community
       delete :destroy, { :did => community.did }
-      expect(response.status).to eq 422
+      expect(response.status).to eq 404
     end
 
     it '200s for dids that belong to a Collection and removes the resource' do 

--- a/spec/controllers/core_files_controller_spec.rb
+++ b/spec/controllers/core_files_controller_spec.rb
@@ -21,8 +21,7 @@ describe CoreFilesController do
       get route, { :did => SecureRandom.uuid } 
   
       expect(response.status).to eq 404 
-      expected_msg = 'No record associated with this did was found.' 
-      expect(response.body).to eq expected_msg
+      expect(response.body).to include 'Resource not found'
     end
 
     it "404s when the CoreFile lacks the requested display type." do
@@ -92,15 +91,15 @@ describe CoreFilesController do
   describe "DELETE destroy" do 
     after(:each) { ActiveFedora::Base.delete_all }
 
-    it "422s for nonexistant dids" do 
+    it "404s for nonexistant dids" do 
       delete :destroy, { :did => "not a real did" }
-      expect(response.status).to eq 422
+      expect(response.status).to eq 404
     end
 
-    it "422s for dids that don't belong to a CoreFile" do 
+    it "404s for dids that don't belong to a CoreFile" do 
       community = Community.create(:did => "115", :depositor => "test")
       delete :destroy, { :did => community.did }
-      expect(response.status).to eq 422
+      expect(response.status).to eq 404
     end
 
     it "200s for dids that belong to a CoreFile and removes the resource" do 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Community do 
+  include FileHelpers
+
   after(:each) { ActiveFedora::Base.delete_all }
 
   it "can create the root community when it doesn't exist" do 
@@ -12,6 +14,35 @@ describe Community do
     Community.root_community
     expect{ Community.root_community }.not_to change{ Community.count }.from(1)
     expect(Community.root_community.pid).to eq Rails.configuration.tap_root
+  end
+
+  describe '#as_json' do 
+    after(:each) { ActiveFedora::Base.delete_all }
+
+    it 'returns a valueless hash for empty Communities' do 
+      result = Community.new.as_json
+      keys = %i(members depositor access thumbnail title description)
+      expect(keys.all? { |k| result.has_key?(k) }).to be true
+      expect(result.all? { |k, v| v.blank? }).to be true
+    end
+
+    it 'populates values appropriately where they exist' do 
+      community = FactoryGirl.create :community
+      community.mods.title = 'A Test Community'
+      community.mods.abstract = 'Community created for testing #as_json' 
+      community.drupal_access = 'public'
+      community.depositor = 'Will Jackson' 
+      community.add_thumbnail(:filepath => fixture_file('image.jpg'))
+      community.project_members = %w(Peter Paul Mary)
+
+      result = community.as_json
+      expect(result[:title]).to eq 'A Test Community'
+      expect(result[:description]).to eq 'Community created for testing #as_json'
+      expect(result[:access]).to eq 'public'
+      expect(result[:depositor]).to eq 'Will Jackson' 
+      expect(result[:thumbnail]).to eq 'image.jpg' 
+      expect(result[:members]).to eq %w(Peter Paul Mary)
+    end
   end
 
   it_behaves_like 'InlineThumbnails'

--- a/spec/shared/api_accessible_spec.rb
+++ b/spec/shared/api_accessible_spec.rb
@@ -3,6 +3,31 @@ require 'spec_helper'
 shared_examples_for "an API enabled controller" do    
   let(:user) { FactoryGirl.create(:user) } 
 
+  describe 'GET #show' do 
+    let(:resource) do 
+      model = described_class.to_s.sub('Controller', '').singularize.underscore
+      FactoryGirl.create :"#{model}"
+    end
+
+    before(:each) { ActiveFedora::Base.destroy_all }
+
+    it '404s for bad requests' do 
+      get :show, { :did => 'not-a-real-did' } 
+      expect(response.status).to eq 404
+    end
+
+    it '200s and returns the object as json for valid requests' do 
+      get :show, { :did => resource.did }
+      expect(response.status).to eq 200 
+
+      full_response = JSON.parse(response.body)
+      puts full_response
+      object = full_response['message'].with_indifferent_access
+
+      expect(object).to eq resource.as_json.with_indifferent_access
+    end
+  end
+
   describe "authentication" do 
     it "raises a 403 for requests with no authorization header" do
       set_auth_token(nil)


### PR DESCRIPTION
Adds an #as_json method to projects/collections/records that can be used to get back a representation of the object showing values that should have been set during a successful insert/update.  Also adds a #show action to all controllers that gives this information to the client.  We need this in the short term to ensure that Drupal only deletes its copy of a given uploaded file when that file has made its way into the repo.