### PR TITLE
Feature/rebuild ri job

### DIFF
--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -31,6 +31,12 @@ class CoreFilesController < ApplicationController
     render_content_asset @core_file.canonical_object, e
   end
 
+  def rebuild_reading_interfaces
+    # Calling perform directly causes the job to execute inline, 
+    # rather than being queued for processing later.
+    RebuildReadingInterfaceJob.perform(params[:did])
+  end
+
   def show 
     @core_file = CoreFile.find_by_did(params[:did])
 

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -32,9 +32,9 @@ class CoreFilesController < ApplicationController
   end
 
   def rebuild_reading_interfaces
-    # Calling perform directly causes the job to execute inline, 
-    # rather than being queued for processing later.
     RebuildReadingInterfaceJob.perform(params[:did])
+    @response[:message] = "Record updated successfully"
+    pretty_json(200) and return
   end
 
   def show 

--- a/app/jobs/rebuild_reading_interface_job.rb
+++ b/app/jobs/rebuild_reading_interface_job.rb
@@ -1,0 +1,30 @@
+class RebuildReadingInterfaceJob
+  @queue = 'tapas_rails_maintenance'
+
+  def self.perform(did)
+    begin
+      core_file = CoreFile.find_by_did(did)
+      return false unless core_file && core_file.project
+
+      core_file.mark_upload_in_progress!
+
+      tei = core_file.canonical_object
+      return false unless tei
+
+      tmpfile = Tempfile.new('ri_rebuild')
+      tmpfile.write(tei.content.content.force_encoding('UTF-8'))
+      tmpfile.rewind
+
+      Content::UpsertReadingInterface.execute_all(core_file, tmpfile.path)
+      core_file.mark_upload_complete!
+    rescue => e
+      core_file.set_default_display_error
+      core_file.set_stacktrace_message(e)
+      core_file.mark_upload_failed!
+      raise e
+    ensure
+      tmpfile.close if tmpfile
+      tmpfile.unlink if tmpfile
+    end
+  end
+end

--- a/app/jobs/rebuild_reading_interface_job.rb
+++ b/app/jobs/rebuild_reading_interface_job.rb
@@ -5,13 +5,12 @@ class RebuildReadingInterfaceJob
     begin
       core_file = CoreFile.find_by_did(did)
       return false unless core_file && core_file.project
-
-      core_file.mark_upload_in_progress!
-
       tei = core_file.canonical_object
       return false unless tei
 
-      tmpfile = Tempfile.new('ri_rebuild')
+      core_file.mark_upload_in_progress!
+
+      tmpfile = Tempfile.new(['ri_rebuild', '.xml'])
       tmpfile.write(tei.content.content.force_encoding('UTF-8'))
       tmpfile.rewind
 

--- a/app/models/concerns/status_tracking.rb
+++ b/app/models/concerns/status_tracking.rb
@@ -42,6 +42,10 @@ module StatusTracking
   end
 
   def mark_upload_complete
+    # Clear any previously set errors
+    self.stacktrace = ''
+    self.errors_display = []
+    self.errors_system = []
     set_status_code('COMPLETE')
   end
 
@@ -54,7 +58,8 @@ module StatusTracking
   end
 
   def mark_upload_complete!
-    set_status_code!('COMPLETE')
+    mark_upload_complete
+    save!
   end
 
   def upload_failed?

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -17,7 +17,7 @@
 
 server 'tapasdev.neu.edu', user: 'tapas_rails', roles: %w{web app db resque_worker resque_scheduler}
 
-set :workers, { "*" => 4 }
+set :workers, { "tapas_rails" => 2, "tapas_rails_maintenance" => 2 }
 
 # Custom SSH Options
 # ==================

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ TapasRails::Application.routes.draw do
   get 'files/:did/tapas_generic' => 'core_files#tapas_generic'
   get 'files/:did/tei' => 'core_files#tei'
   get 'files/:did' => 'core_files#show'
+  put 'files/:did/reading_interfaces' => 'core_files#rebuild_reading_interfaces'
   post 'files/:did' => 'core_files#upsert'
   delete "files/:did" => "core_files#destroy"
 

--- a/spec/controllers/core_files_controller_spec.rb
+++ b/spec/controllers/core_files_controller_spec.rb
@@ -174,10 +174,26 @@ describe CoreFilesController do
   end
 
   describe "PUT #rebuild_reading_interfaces" do 
+    after(:each) { ActiveFedora::Base.delete_all }
+
     it 'raises a 404 for dids that do not exist' do
       put :rebuild_reading_interfaces, did: 'no-such-did' 
 
       expect(response.status).to eq 404
+    end
+
+    it 'returns a 200 on successful reading interface rebuild' do 
+      core, collections, community = FixtureBuilders.create_all
+      tei = FactoryGirl.create :tei_file
+
+      tei.core_file = core
+      tei.canonize
+      tei.add_file(File.read(fixture_file('tei.xml')), 'content', 'tei.xml')
+      tei.save! 
+
+      put :rebuild_reading_interfaces, did: core.did 
+
+      expect(response.status).to eq 200 
     end
   end
 

--- a/spec/controllers/core_files_controller_spec.rb
+++ b/spec/controllers/core_files_controller_spec.rb
@@ -173,6 +173,13 @@ describe CoreFilesController do
     end
   end
 
+  describe "PUT #rebuild_reading_interfaces" do 
+    it 'raises a 404 for dids that do not exist' do
+      put :rebuild_reading_interfaces, did: 'no-such-did' 
+
+      expect(response.status).to eq 404
+    end
+  end
 
   describe "POST #upsert" do
     let(:post_defaults) do 

--- a/spec/jobs/rebuild_reading_interface_job_spec.rb
+++ b/spec/jobs/rebuild_reading_interface_job_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe RebuildReadingInterfaceJob do 
+  include FileHelpers
+  include FixtureBuilders
+
+  after(:each) { ActiveFedora::Base.delete_all }
+
+  let(:core) { FactoryGirl.create :core_file } 
+  let(:tei) { FactoryGirl.create :tei_file }
+
+  it 'returns false when called on a nonexistent did' do 
+    expect(RebuildReadingInterfaceJob.perform('no_did')).to be false
+  end
+
+  it 'returns false when called on a CoreFile with no TEI' do 
+    expect(RebuildReadingInterfaceJob.perform(core.did)).to be false
+  end
+
+  it 'rebuilds the reading interface when given a valid CoreFile' do
+    cf, cl, p = FixtureBuilders.create_all
+    tei.core_file = cf
+    tei.canonize
+    tei.content.content = File.read(fixture_file('tei.xml'))
+    tei.save! ; cf.reload
+
+    cf.mark_upload_failed! 
+
+    RebuildReadingInterfaceJob.perform(cf.did)
+
+    cf.reload
+
+    expect(cf.upload_complete?).to be true 
+    expect(cf.teibp).not_to be nil 
+    expect(cf.tapas_generic).not_to be nil
+  end
+end 

--- a/spec/models/concerns/status_tracking_spec.rb
+++ b/spec/models/concerns/status_tracking_spec.rb
@@ -58,4 +58,20 @@ describe StatusTracking do
       expect(tracker.stuck_in_progress?).to be true 
     end
   end
+
+  describe '#mark_upload_complete' do 
+    let(:tracker) { StatusTrackerTest.new }
+
+    it 'clears previously set errors' do 
+      tracker.stacktrace = "Some stacktrace" 
+      tracker.errors_system = ['some errors']
+      tracker.errors_display = ['more errors'] 
+      
+      tracker.mark_upload_complete!
+
+      expect(tracker.stacktrace).to be_blank
+      expect(tracker.errors_system).to be_blank
+      expect(tracker.errors_display).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
Adds a job for rebuilding the reading interface of every record, also adds an endpoint that synchronously rebuilds the reading interface for a single TEI Record.