### PR TITLE
Create ApplicationRecord superclass and make app models inherit from it

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Collection < ActiveRecord::Base
+class Collection < ApplicationRecord
   include Discard::Model
   include SolrHelpers
 

--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CoreFile < ActiveRecord::Base
+class CoreFile < ApplicationRecord
   include Discard::Model
   include SolrHelpers
 

--- a/app/models/html_file.rb
+++ b/app/models/html_file.rb
@@ -1,4 +1,4 @@
-class HTMLFile < ActiveRecord::Base
+class HTMLFile < ApplicationRecord
   include Filename
   include DownloadPath
   include TapasRails::ViewPackages

--- a/app/models/image_file.rb
+++ b/app/models/image_file.rb
@@ -1,4 +1,4 @@
-class ImageFile < ActiveRecord::Base
+class ImageFile < ApplicationRecord
   # associations
   belongs_to :imageable, polymorphic: true
   # belongs_to :depositor, class_name: "User"

--- a/app/models/menu_link.rb
+++ b/app/models/menu_link.rb
@@ -1,4 +1,4 @@
-class MenuLink < ActiveRecord::Base
+class MenuLink < ApplicationRecord
   attr_accessible :link_text, :link_href, :classes, :link_order, :parent_link_id, :menu_name if Rails::VERSION::MAJOR < 4
   validates_presence_of :link_text, :link_href, :menu_name
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,4 +1,4 @@
-class NewsItem < ActiveRecord::Base
+class NewsItem < ApplicationRecord
   extend FriendlyId
   include SolrHelpers
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,4 @@
-class Page < ActiveRecord::Base
+class Page < ApplicationRecord
   extend FriendlyId
   include SolrHelpers
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Project < ActiveRecord::Base
+class Project < ApplicationRecord
   include Discard::Model
   include SolrHelpers
 

--- a/app/models/project_collection.rb
+++ b/app/models/project_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProjectCollection < ActiveRecord::Base
+class ProjectCollection < ApplicationRecord
   belongs_to :project
   belongs_to :collection
 end

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProjectMember < ActiveRecord::Base
+class ProjectMember < ApplicationRecord
   # constants
   ROLES = %w[contributor collaborator owner]
 

--- a/app/models/tei_file.rb
+++ b/app/models/tei_file.rb
@@ -1,4 +1,4 @@
-class TEIFile < ActiveRecord::Base
+class TEIFile < ApplicationRecord
   include Filename
   include DownloadPath
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 require "net/http"
 require "uri"
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   include Blacklight::User
 
   has_one_attached(:image_file)

--- a/app/models/view_package.rb
+++ b/app/models/view_package.rb
@@ -1,4 +1,4 @@
-class ViewPackage < ActiveRecord::Base
+class ViewPackage < ApplicationRecord
   include TapasRails::ViewPackages
   attr_accessible :human_name, :machine_name, :description, :file_type, :css_files, :js_files, :parameters, :run_process, :dir_name, :git_timestamp, :git_branch if Rails::VERSION::MAJOR < 4
 


### PR DESCRIPTION
When we upgraded from Rails 4 to 5, we needed to create `application_record.rb` and use that as a superclass for all app models.

I followed instructions from the [Rails upgrading guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-models-now-inherit-from-applicationrecord-by-default). I was able to successfully run the Rails server using my changes.