### PR TITLE
Refactor Project-CoreFile association from many-to-many to one-to-many

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,10 @@ saxon-js-compilation.md
 .vscode/
 # Ignore bundler config.
 /.bundle
-app_navigator.rb
-tapas_xq_query_syntax.rb
+admin_documentation/app_navigator.rb
+admin_documentation/tapas_xq_query_syntax.rb
 cch_admin_test_record.xml
-migrations.txt
+admin_documentation/migrations.txt
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
@@ -48,7 +48,7 @@ capybara-*.html
 **.orig
 config/initializers/secret_token.rb
 config/secrets.yml
-db_architecture.md
+admin_documentation/db_architecture.md
 
 ## Environment normalisation:
 /.bundle
@@ -94,3 +94,4 @@ all-db_04102023.sql
 /to-do.txt
 /.nvmrc
 /storage/
+/admin_documentation/

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -34,7 +34,8 @@ class CollectionsController < ApplicationController
 
   def new
     @page_title = "Create New Collection"
-    @projects = Project.joins(:project_members).where(project_members: { user_id: current_user.id, role: ["editor", "admin"] })
+    @projects = Project.joins(:project_members).where(project_members: { user_id: current_user.id, role: ["owner", "collaborator"] })
+    @project = Project.find(params[:project]) if params[:project]
     @collection = Collection.new(project: @project)
   end
 

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -243,8 +243,9 @@ class CoreFilesController < ApplicationController
       :depositor,
       :description,
       :featured,
+      :is_public,
       :title,
-      :collections => [],
+      :collection_ids => [],
       :tei_authors => [],
       :tei_contributors => [],
       :thumbnails => []

--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -8,8 +8,8 @@ class CoreFile < ApplicationRecord
   belongs_to :depositor, class_name: "User"
   has_many :collections_core_files, dependent: :destroy
   has_many :collections, through: :collections_core_files
-  has_many :core_files_projects, dependent: :destroy
-  has_many :projects, through: :core_files_projects
+  has_one :core_files_project, dependent: :destroy
+  has_one :project, through: :core_files_project
   # has_and_belongs_to_many :users
   has_one_attached :tei_file
   has_one :image_file, as: :imageable, dependent: :destroy
@@ -21,8 +21,8 @@ class CoreFile < ApplicationRecord
   validate :tei_file_attached, unless: :is_ography?
 
   # Callbacks
-  after_save :index_core_file
   after_save :sync_project_association
+  after_save :index_core_file
   #TODO: add a callback to locate the indexed record by both active_record_model_ssi and id before deleting
   after_update :update_indexed_core_file
   # these strings refer to the role of the file in collection(s);
@@ -41,11 +41,6 @@ class CoreFile < ApplicationRecord
   #     collections << Collection.find(collection_id)
   #   end
   # end
-
-  def project
-    # All collections that a CoreFile belongs to will belong to the same project
-    collections.first&.project
-  end
 
   # def collections
   #   collection_ids.map { |collection_id| Collection.find(collection_id) }
@@ -167,7 +162,7 @@ class CoreFile < ApplicationRecord
       'depositor_tesim' => depositor_id,
       'table_id_ssi' => id,
       'id' => "#{self.class.to_s}_#{id}",
-      'edit_access_person_ssim' => project.members.empty? ? depositor_id : project.owner[0].id,
+      'edit_access_person_ssim' => (project&.members&.dig('owner', 0)&.id || depositor_id),
       # these two replace the is_member_of_ssim field
       'collections_ssim' => self.collections.map(&:id),
       'projects_ssim' => self.collections.map(&:project_id),
@@ -257,21 +252,32 @@ class CoreFile < ApplicationRecord
   end
 
   def sync_project_association
-    # Maintain the core_files_projects join table in sync with collections
+    # Maintain the core_files_project join table in sync with collections
     # All collections must belong to the same project (enforced by validation)
     return unless collections.any?
 
-    project = collections.first.project
-    return unless project
+    collection_project = collections.first.project
 
-    # Add project association if not already present
-    unless projects.include?(project)
-      projects << project
+    if collection_project.nil?
+      raise ActiveRecord::RecordInvalid, "CoreFile #{id} has collections but collection #{collections.first.id} has no associated project"
     end
 
-    # Remove any project associations that don't match the collections' project
-    projects.where.not(id: project.id).each do |old_project|
-      projects.delete(old_project)
+    # Directly manage the join table record instead of using the association setter
+    # Find or create the CoreFilesProject record
+    existing_join = CoreFilesProject.find_by(core_file_id: id)
+
+    if existing_join
+      # Update if the project has changed
+      if existing_join.project_id != collection_project.id
+        existing_join.update_columns(project_id: collection_project.id)
+      end
+    else
+      # Create new join record, bypassing validations that check call stack
+      join_record = CoreFilesProject.new(
+        core_file_id: id,
+        project_id: collection_project.id
+      )
+      join_record.save(validate: false)
     end
   end
 

--- a/app/models/core_files_project.rb
+++ b/app/models/core_files_project.rb
@@ -7,6 +7,39 @@ class CoreFilesProject < ApplicationRecord
   belongs_to :project
   belongs_to :core_file
 
+  # Prevent direct manipulation - this table should only be managed via CoreFile callbacks
+  validate :prevent_direct_manipulation, on: :create
+  validate :ensure_core_file_belongs_to_project_collections, on: :create
+
   # Note: This table should be treated as read-only from the application perspective
   # The CoreFile model manages these associations via sync_project_association callback
+
+  private
+
+  def prevent_direct_manipulation
+    # Allow creation only if called from within the CoreFile model's callback
+    # Check the call stack to see if we're being called from sync_project_association
+    caller_locations = caller_locations(1, 20)
+    allowed_caller = caller_locations.any? do |location|
+      location.path.include?('core_file.rb') &&
+      (location.label == 'sync_project_association' || location.label == 'project=')
+    end
+
+    unless allowed_caller
+      errors.add(:base, "CoreFilesProject records can only be created via CoreFile's sync_project_association callback. " \
+                        "Add the core file to a collection instead of directly to a project.")
+    end
+  end
+
+  def ensure_core_file_belongs_to_project_collections
+    return unless core_file && project
+
+    # Verify that the core file actually has collections in this project
+    core_file_project_ids = core_file.collections.map(&:project_id).compact.uniq
+
+    unless core_file_project_ids.include?(project_id)
+      errors.add(:base, "Cannot associate CoreFile #{core_file_id} with Project #{project_id}. " \
+                        "Core file's collections belong to project(s): #{core_file_project_ids.join(', ')}")
+    end
+  end
 end

--- a/app/models/image_file.rb
+++ b/app/models/image_file.rb
@@ -4,6 +4,8 @@ class ImageFile < ApplicationRecord
   # belongs_to :depositor, class_name: "User"
   has_one_attached :file
 
+  #TODO: create a constant accessible throughout the app that returns an array with all acceptable image file types
+
   # validations
   validates_presence_of :title, :depositor_id
   validate :file_format

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,18 @@ class Project < ApplicationRecord
   # files should be added to a new collection in that project, should delete the record associated with core file on the
   # project_core_files join table;
 
+  # Prevent direct manipulation of core_files association
+  # Core files should be added to projects via collections only
+  # Note: The << operator cannot be easily overridden on has_many :through associations
+  # The CoreFilesProject join model has validations that prevent direct manipulation
+
+  def core_files=(core_files_array)
+    raise ActiveRecord::RecordInvalid,
+          "Cannot assign core files directly to projects. "
+          "Add core files to collections within this project instead. "
+          "The project-core_file association is automatically maintained based on collections."
+  end
+
   # callbacks
   after_save :index_record
   after_update :update_record

--- a/app/views/collections/_data_form.html.haml
+++ b/app/views/collections/_data_form.html.haml
@@ -22,8 +22,8 @@
         .form-group
           = f.label :thumbnail, "Thumbnail", class: "control-label col-md-2"
           .col-md-6
-            - if @collection.thumbnail.attached?
-              =image_tag url_for(@collection.thumbnail)
+            - if @collection.image_file&.file&.attached?
+              =image_tag @collection.thumbnail
               = f.label :remove_thumbnail, "Remove Thumbnail"
               = f.check_box "remove_thumbnail", { :checked => false }
             = f.file_field :thumbnails, direct_upload: true

--- a/app/views/core_files/_data_form.html.haml
+++ b/app/views/core_files/_data_form.html.haml
@@ -26,10 +26,10 @@
             %p.small.help-block="This field accepts plain text"
 
         .form-group
-          = f.label :collections, "Collections", class: "control-label col-md-2"
+          = f.label :collection_ids, "Collections", class: "control-label col-md-2"
           .col-md-6
             %span.collection
-              = f.select :collections, options_from_collection_for_select(@collections, 'id', 'title', @core_file.collections.map(&:id)), {}, {class: "form-control", multiple: true}
+              = f.select :collection_ids, options_from_collection_for_select(@collections, 'id', 'title', @core_file.collection_ids), {}, {class: "form-control", multiple: true}
 
         -# TODO: (charles) Figure out why we need Ography Type and reimplement it
         -# .form-group

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -149,17 +149,14 @@ namespace :dummy_data_generator do
   end
 
   def create_core_files
-    Collection.all.shuffle.each do |collection|
-      file_count_range = 1..10
-      file_counter = file_count_range.to_a.sample
+    Collection.all.each do |collection|
       project = collection.project
       collection_users = project.members.values.flatten.shuffle
       visibility = collection.is_public
       ography_types = CoreFile.all_ography_types
-      file_count = file_counter.even? ? file_counter : file_counter + 1
 
-        # Create regular TEI content files
-      file_count.times do |i|
+      # Create 3 regular TEI content files
+      3.times do |i|
         core_file = CoreFile.new(title: Faker::Book.title,
                         description: Faker::Book.genre,
                         depositor_id: collection_users.sample&.id,
@@ -181,7 +178,7 @@ namespace :dummy_data_generator do
       end
 
       # Create 3 ography support files (don't need TEI)
-      file_count.times do
+      2.times do
         core_file = CoreFile.create(title: Faker::Book.title,
                         description: Faker::Book.genre,
                         depositor_id: collection_users.sample&.id,

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -149,14 +149,17 @@ namespace :dummy_data_generator do
   end
 
   def create_core_files
-    Collection.all.each do |collection|
+    Collection.all.shuffle.each do |collection|
+      file_count_range = 1..10
+      file_counter = file_count_range.to_a.sample
       project = collection.project
       collection_users = project.members.values.flatten.shuffle
       visibility = collection.is_public
       ography_types = CoreFile.all_ography_types
+      file_count = file_counter.even? ? file_counter : file_counter + 1
 
-      # Create 3 regular TEI content files
-      3.times do |i|
+        # Create regular TEI content files
+      file_count.times do |i|
         core_file = CoreFile.new(title: Faker::Book.title,
                         description: Faker::Book.genre,
                         depositor_id: collection_users.sample&.id,
@@ -178,7 +181,7 @@ namespace :dummy_data_generator do
       end
 
       # Create 3 ography support files (don't need TEI)
-      2.times do
+      file_count.times do
         core_file = CoreFile.create(title: Faker::Book.title,
                         description: Faker::Book.genre,
                         depositor_id: collection_users.sample&.id,


### PR DESCRIPTION
## Summary
  - Converts the Project-CoreFile association from `has_many :through`
  (many-to-many) to `has_one :through` (one-to-many), enforcing that a CoreFile can only belong to one project
  - Adds validations to `CoreFilesProject` join model that prevent direct manipulation and ensure core files are only associated with projects through their collections
  - Updates `sync_project_association` callback to maintain a single project association using direct SQL updates to avoid infinite callback loops
  - Adds `core_files=` setter override in Project model that raises an error if attempting to directly assign core files to a project
  - Updates controller permitted params and view forms to use `collection_ids` instead of `collections`
  - Updates role checking from "editor"/"admin" to "owner"/"collaborator" in collections controller
  - Improves dummy data generator with randomized file counts per collection

  ## Resolves Issue #118
  This PR addresses issue #118 by changing the Project-CoreFile relationship from many-to-many to one-to-many. The previous association allowed a CoreFile to theoretically belong to multiple projects, which went against requirements that all collections a CoreFile belongs to must be in the same project. With this change, the project association is now automatically managed through collection membership, and validations prevent direct manipulation of the join table to maintain data integrity.

  ## Steps to Test
  - [ ] Create a new CoreFile and add it to one or more collections within the same project - verify the project association is automatically created
  - [ ] Try to add a CoreFile to collections from different projects - verify validation fails with appropriate error message
  - [ ] Try to directly assign core files to a project using `project.core_files = [core_file]` - verify it raises an error
  - [ ] Update a CoreFile's collections - verify the project association updates automatically
  - [ ] Run the dummy data generator task (`rake dummy_data_generator:create_all`) - verify it completes successfully
  - [ ] Test creating collections from the UI with the updated role checks (owner/collaborator)
  - [ ] Verify existing CoreFiles with collections maintain correct project associations after migration