### PR TITLE
Sortable "Browse Projects" page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ all-db_04102023.sql
 /config/master.key
 /db/data/
 /to-do.txt
+
+# Ignore git patch files
+*.patch

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -9,6 +9,7 @@
   :root {
     
     --tapas-border-color: #888;
+    --tapas-border-light: #CBCBCB;
     // Use Bootstrap's default border variables to keep things looking cohesive
     --tapas-border-radius: var(--bs-border-radius);
     
@@ -208,6 +209,7 @@ h1, h2, h3, h4, h5, h6 {
 .flex-spaced {
   display: flex;
   flex-wrap: wrap;
+  gap: 0.75em;
   justify-content: space-between;
 }
 
@@ -237,19 +239,35 @@ ul.inline-list {
   padding-left: 0;
 }
 
+.sidebar {
+  border: thin solid var(--tapas-border-light);
+  border-radius: var(--tapas-border-radius);
+  padding: 0.75em 1em;
+}
+
 form.sort-controls {
-  align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35em 0.75em;
+  gap: 0.5em 0.75em;
   height: 100%;
   
   @media screen and (min-width: $medium-screen) {
-    margin: 0 1rem;
+    align-items: start;
+    flex-direction: column;
   }
   
+  > div {
+    display: flex;
+    gap: 0.35em;
+    
+    @media screen and (min-width: $medium-screen) {
+      flex-direction: column;
+      width: 100%;
+    }
+  } // form.sort-controls > div
+  
   label {
-    margin-left: 0.35em;
+    //margin-left: 0.35em;
     
     &:first-child {
       margin-left: 0;
@@ -412,8 +430,7 @@ form.sort-controls {
   /* Breadcrumbs */
   nav.breadcrumbs {
     border-radius: var(--tapas-border-radius);
-    border: thin solid #DDD;
-    //background-color: #EBEBEB;
+    border: thin solid var(--tapas-border-light);
     font-weight: 400;
     margin-bottom: 1.5rem;
     padding: 0.25rem 0.75rem;
@@ -447,6 +464,39 @@ form.sort-controls {
     margin-top: 2rem;
   }
 } // end .main-container
+
+
+/*
+ * BROWSE PAGE CONTENT
+ */
+
+.browse-content {
+  display: grid;
+  grid-gap: 1rem 1.5rem;
+  
+  @media screen and (min-width: $medium-screen) {
+    align-items: start;
+    grid-auto-columns: 1fr 5fr;
+    grid-template-areas: 
+      "heading  heading"
+      "pagenav1 pagenav1"
+      "sidebar  list"
+      "sidebar  pagenav2";
+    
+    > h1 { grid-area: heading; }
+    > .flex-spaced { grid-area: pagenav1; }
+    > .sidebar { grid-area: sidebar; }
+    > .container-sequence { grid-area: list; }
+    > .pagination-container { grid-area: pagenav2; }
+  }
+  
+  > h1,
+  .btn-list,
+  .container-sequence,
+  .pagination {
+    margin-bottom: 0;
+  }
+} // end .browse-content
 
 
 /*
@@ -499,7 +549,7 @@ ol.container-sequence {
     
     .tapas-container-name {
       flex: 1 2 50%;
-      font-size: 1.75rem; // same size as <h3>
+      font-size: 1.5rem;
     }
     
     .tapas-container-info {

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -92,52 +92,6 @@ label {
   font-size: 1.15em;
 }
 
-ul.btn-list,
-ol.btn-list {
-  display: flex;
-  gap: 0.75em;
-  padding-left: 0.25rem;
-  
-  li {
-    list-style: none;
-  }
-} // end .btn-list
-
-/* The "inline-list" class is intended to add a little extra spacing between list 
-  items formatted as inline text. Note that this class should be used mostly for 
-  small snippets of text, such as names. */
-.inline-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0 0.65em;
-}
-ol.inline-list,
-ul.inline-list {
-  padding-left: 0;
-}
-
-form.sort-controls {
-  align-items: center;
-  display: flex;
-  gap: 0.75em;
-  height: 100%;
-  margin: 0 1rem;
-  
-  label {
-    margin-left: 0.35em;
-    
-    &:first-child {
-      margin-left: 0;
-    }
-  } // end form.sort-controls label
-  
-  /* Override the `width: 100%` rule set by Bootstrap, which will cut off part of 
-    the <option> text when inside a flexbox. */
-  .form-select {
-    width: unset;
-  }
-} // end form.sort-controls
-
 img.thumbnail {
   max-height: 3rem;
   max-width: 3rem;
@@ -245,6 +199,74 @@ h1, h2, h3, h4, h5, h6 {
     }
   } // end & .nav-link
 } // end .nav-tabs
+
+
+/*
+ * COMMON CONTENT CONTAINERS
+ */
+
+.flex-spaced {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+ul.btn-list,
+ol.btn-list {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em 0.75em;
+  padding-left: 0.25rem;
+  
+  li {
+    list-style: none;
+  }
+} // end .btn-list
+
+/* The "inline-list" class is intended to add a little extra spacing between list 
+  items formatted as inline text. Note that this class should be used mostly for 
+  small snippets of text, such as names. */
+.inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 0.65em;
+}
+ol.inline-list,
+ul.inline-list {
+  padding-left: 0;
+}
+
+form.sort-controls {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em 0.75em;
+  height: 100%;
+  
+  @media screen and (min-width: $medium-screen) {
+    margin: 0 1rem;
+  }
+  
+  label {
+    margin-left: 0.35em;
+    
+    &:first-child {
+      margin-left: 0;
+    }
+  } // end form.sort-controls label
+  
+  /* Override the `width: 100%` rule set by Bootstrap, which will cut off part of 
+    the <option> text when inside a flexbox. */
+  .form-select {
+    width: unset;
+  }
+} // end form.sort-controls
+
+.pagination-container {
+  display: flex;
+  justify-content: end;
+}
 
 
 /* 

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -13,7 +13,9 @@
     // Use Bootstrap's default border variables to keep things looking cohesive
     --tapas-border-radius: var(--bs-border-radius);
     
+    
     /* TAPAS-specific variables */
+    
     --tapas-block-main: white;
     --tapas-block-dark: #26333F;
     --tapas-block-mid: #3F5A74; /* originally #4E5D6C */
@@ -32,18 +34,9 @@
     
     --tapas-text-dark: #090909;
     --tapas-text-light: #EBEBEB;
+    --tapas-text-underline-thickness: 0.085rem;
     
     --tapas-transparency: rgba(0,0,0,0);
-    
-    /* Reset Bootstrap defaults: */
-    --bs-border-color: var(--tapas-border-color);
-    --bs-body-color: var(--tapas-text-dark);
-    .table {
-      --bs-table-striped-bg: var(--tapas-block-light);
-    }
-    .btn-primary {
-      --bs-btn-bg: var(--tapas-button-color);
-    }
   }
 
 
@@ -71,9 +64,8 @@ h1, .h1 {
 }
 
 a {
-  text-decoration: underline dotted;
+  text-decoration: underline dotted var(--tapas-text-underline-thickness);
   text-underline-offset: 0.25em;
-  text-decoration-thickness: 0.085rem;
   
   &:hover, &:focus {
     text-decoration-style: solid;
@@ -136,6 +128,21 @@ button.collapse-toggle {
 /*
  * BOOTSTRAP STYLE OVERRIDES
  */
+
+/* Set new values for Bootstrap's CSS variables. */
+:root {
+  --bs-border-color: var(--tapas-border-color);
+  --bs-body-color: var(--tapas-text-dark);
+  
+  .btn-primary {
+    --bs-btn-bg: var(--tapas-button-color);
+  }
+  
+  .table {
+    --bs-table-striped-bg: var(--tapas-block-light);
+  }
+} // end resetting Bootstrap variables
+
 
 @media (min-width: $medium-screen) {
   
@@ -200,6 +207,26 @@ h1, h2, h3, h4, h5, h6 {
     }
   } // end & .nav-link
 } // end .nav-tabs
+  
+.pagination {
+  --bs-pagination-active-bg: var(--tapas-block-main);
+  --bs-pagination-active-border-color: var(--tapas-border-color);
+  --bs-pagination-active-color: var(--tapas-text-dark);
+  --bs-pagination-hover-bg: var(--tapas-block-light);
+  --bs-pagination-hover-color: var(--tapas-link-hover);
+  
+  a.page-link {
+    transition: none;
+    
+    &:hover {
+      text-decoration: underline var(--tapas-text-underline-thickness);
+    }
+  } // end .pagination .page-link
+  
+  span.page-link.active {
+    cursor: default;
+  }
+} // end .pagination
 
 
 /*
@@ -248,7 +275,7 @@ ul.inline-list {
 form.sort-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5em 0.75em;
+  gap: 0.75em;
   height: 100%;
   
   @media screen and (min-width: $medium-screen) {
@@ -282,7 +309,9 @@ form.sort-controls {
 } // end form.sort-controls
 
 .pagination-container {
+  align-items: baseline;
   display: flex;
+  gap: 0.75em;
   justify-content: end;
 }
 
@@ -476,25 +505,39 @@ form.sort-controls {
   
   @media screen and (min-width: $medium-screen) {
     align-items: start;
-    grid-auto-columns: 1fr 5fr;
+    grid-auto-columns: 2fr 4fr;
     grid-template-areas: 
       "heading  heading"
-      "pagenav1 pagenav1"
+      "summary  pagenav1"
       "sidebar  list"
       "sidebar  pagenav2";
     
     > h1 { grid-area: heading; }
+    > .pagination-summary { grid-area: summary; }
     > .flex-spaced { grid-area: pagenav1; }
     > .sidebar { grid-area: sidebar; }
     > .container-sequence { grid-area: list; }
-    > .pagination-container { grid-area: pagenav2; }
-  }
+    > .pagination-container:last-child { grid-area: pagenav2; }
+  } // end medium screen .browse-content
+  
+  @media screen and (min-width: $large-screen) {
+    grid-auto-columns: 1.5fr 5fr;
+    
+    input[type="submit"] {
+      max-width: 100px;
+    }
+  } // end large screen .browse-content
   
   > h1,
   .btn-list,
   .container-sequence,
+  .pagination-summary,
   .pagination {
     margin-bottom: 0;
+  }
+  
+  .pagination-summary {
+    align-self: center;
   }
 } // end .browse-content
 

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -129,19 +129,11 @@ button.collapse-toggle {
  * BOOTSTRAP STYLE OVERRIDES
  */
 
-/* Set new values for Bootstrap's CSS variables. */
+/* Set new values for Bootstrap's global CSS variables. */
 :root {
   --bs-border-color: var(--tapas-border-color);
   --bs-body-color: var(--tapas-text-dark);
-  
-  .btn-primary {
-    --bs-btn-bg: var(--tapas-button-color);
-  }
-  
-  .table {
-    --bs-table-striped-bg: var(--tapas-block-light);
-  }
-} // end resetting Bootstrap variables
+}
 
 
 @media (min-width: $medium-screen) {
@@ -162,6 +154,10 @@ button.collapse-toggle {
     color: var(--tapas-text-dark);
   }
 } // end .alert
+  
+.btn-primary {
+  --bs-btn-bg: var(--tapas-button-color);
+}
 
 .card-sequence {
   display: flex;
@@ -227,6 +223,10 @@ h1, h2, h3, h4, h5, h6 {
     cursor: default;
   }
 } // end .pagination
+
+.table {
+  --bs-table-striped-bg: var(--tapas-block-light);
+}
 
 
 /*

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -122,6 +122,20 @@ form.sort-controls {
   gap: 0.75em;
   height: 100%;
   margin: 0 1rem;
+  
+  label {
+    margin-left: 0.35em;
+    
+    &:first-child {
+      margin-left: 0;
+    }
+  } // end form.sort-controls label
+  
+  /* Override the `width: 100%` rule set by Bootstrap, which will cut off part of 
+    the <option> text when inside a flexbox. */
+  .form-select {
+    width: unset;
+  }
 } // end form.sort-controls
 
 img.thumbnail {

--- a/app/assets/stylesheets/tapas.scss
+++ b/app/assets/stylesheets/tapas.scss
@@ -103,6 +103,19 @@ ol.btn-list {
   }
 } // end .btn-list
 
+/* The "inline-list" class is intended to add a little extra spacing between list 
+  items formatted as inline text. Note that this class should be used mostly for 
+  small snippets of text, such as names. */
+.inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 0.65em;
+}
+ol.inline-list,
+ul.inline-list {
+  padding-left: 0;
+}
+
 form.sort-controls {
   align-items: center;
   display: flex;
@@ -373,9 +386,6 @@ h1, h2, h3, h4, h5, h6 {
       margin-bottom: 0;
     }
   } // end .main-container nav.breadcrumbs
-  
-  
-  
   
   #main-content {
     

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -13,15 +13,11 @@ module ListResources
     
     # If the user requested a valid sort direction, use that.
     order_param = params[:sort_direction]
-    if is_valid_sort_direction(order_param)
-      @sort_direction = order_param
-    # If the user didn't specify and the sort method is "updated_at", use descending order (most recent first).
-    elsif @sort_method == 'updated_at'
-      @sort_direction = 'DESC'
-    # Otherwise, use ascending order.
-    else
-      @sort_direction = 'ASC'
-    end
+    @sort_direction = 
+      is_valid_sort_direction(order_param) ? order_param.to_s.upcase :
+      # If there isn't a given sort order but the method is "updated_at", sort the newest first.
+      # Otherwise, use ascending order.
+      @sort_method == 'updated_at' ? 'DESC' : 'ASC'
   end
   
   def sort_string
@@ -32,12 +28,12 @@ module ListResources
   # if the request parameter is provided and its lower-cased value matches one of the approved strings.
   def is_valid_sort_method(sort_method = browse_params[:sort])
     allowed_methods = %w(title updated_at)
-    !sort_method.blank? && allowed_methods.include?(sort_method.to_s.downcase)
+    sort_method.present? && allowed_methods.include?(sort_method.to_s.downcase)
   end
   
   def is_valid_sort_direction(direction = browse_params[:sort_direction])
-    allowed_order = %w(desc asc)
-    !direction.blank? && allowed_order.include?(direction.to_s.downcase)
+    allowed_order = %w(ASC DESC)
+    direction.present? && allowed_order.include?(direction.to_s.upcase)
   end
   
   # For requests to a Browse page, permit only the sorting parameters.

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -2,17 +2,27 @@
 module ListResources
   extend ActiveSupport::Concern
   
+  SORT_OPTIONS = [
+    ["date created", 'created_at'], 
+    ["date updated", 'updated_at'], 
+    ['title', 'title']
+  ].freeze
+  
   DEFAULT_SORT = 'updated_at'
   
-  # Set up the variables we'll need for constructing a Browse page. This method has the option to
-  # include the request parameters in case we need specialized parameters for a particular kind of model.
-  def set_up_browse(params = browse_params)
+  # Gather information about sorting for this resource type.
+  def set_sorting(add_sort_options = [])
+    @sort_options = SORT_OPTIONS.dup
+    if ( add_sort_options.present? )
+      @sort_options.concat(add_sort_options)
+    end
+    
     # If the user requested a valid sort method, use that. Otherwise, use the default method.
-    sort_param = params[:sort]
+    sort_param = browse_params[:sort]
     @sort_method = is_valid_sort_method(sort_param) ? sort_param : DEFAULT_SORT
     
     # If the user requested a valid sort direction, use that.
-    order_param = params[:sort_direction]
+    order_param = browse_params[:sort_direction]
     @sort_direction = 
       is_valid_sort_direction(order_param) ? order_param.to_s.upcase :
       # If there isn't a given sort order but the method is "updated_at", sort the newest first.
@@ -24,13 +34,17 @@ module ListResources
     @sort_method+" "+@sort_direction
   end
   
+  def allowed_sort_methods
+    @sort_options.map{ |option| option.last }
+  end
+  
   # Test a requested sort method string against the methods we are prepared to accept. Returns true ONLY 
   # if the request parameter is provided and its lower-cased value matches one of the approved strings.
   def is_valid_sort_method(sort_method = browse_params[:sort])
-    allowed_methods = %w(created_at title updated_at)
-    sort_method.present? && allowed_methods.include?(sort_method.to_s.downcase)
+    sort_method.present? && allowed_sort_methods.include?(sort_method.to_s.downcase)
   end
   
+  # Test that a requested sort direction is provided AND is either "ASC" or "DESC" (case insensitive).
   def is_valid_sort_direction(direction = browse_params[:sort_direction])
     allowed_order = %w(ASC DESC)
     direction.present? && allowed_order.include?(direction.to_s.upcase)

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -1,11 +1,31 @@
+# Methods common to the Browse pages (and possibly Search)
 module ListResources
   extend ActiveSupport::Concern
   
+  DEFAULT_SORT = 'updated_at'
+  
+  # Set up the variables we'll need for constructing a Browse page. This method has the option to
+  # include the request parameters in case we need specialized parameters for a particular kind of model.
+  def set_up_browse(params = browse_params)
+    sort_param = params[:sort]
+    # If the user requested a valid sort method, use that. Otherwise, use the default method.
+    @sort_method = is_valid_sort_method(sort_param) ? sort_param : DEFAULT_SORT
+    # Decide for the user whether to apply the sort method in ascending or descending order.
+    @sort_direction = @sort_method == 'updated_at' ? 'DESC' : 'ASC'
+  end
+  
+  def sort_string
+    @sort_method+" "+@sort_direction
+  end
+  
+  # Test a requested sort method string against the methods we are prepared to accept. Returns true ONLY 
+  # if the request parameter is provided and its lower-cased value matches one of the approved strings.
   def is_valid_sort_method(method = browse_params[:sort])
     allowed_methods = %w(title updated_at)
     !method.blank? && allowed_methods.include?(method.to_s.downcase)
   end
   
+  # For requests to a Browse page, permit only the sort parameter.
   def browse_params
     params.permit(:sort)
   end

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -1,9 +1,10 @@
 module ListResources
   extend ActiveSupport::Concern
   
-  #def is_valid_sort_method
-    
-  #end
+  def is_valid_sort_method(method = browse_params[:sortBy])
+    allowed_methods = %w(title updated_at)
+    !method.blank? && allowed_methods.include?(method.to_s.downcase)
+  end
   
   def browse_params
     params.permit(:sortBy)

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -1,12 +1,12 @@
 module ListResources
   extend ActiveSupport::Concern
   
-  def is_valid_sort_method(method = browse_params[:sortBy])
+  def is_valid_sort_method(method = browse_params[:sort])
     allowed_methods = %w(title updated_at)
     !method.blank? && allowed_methods.include?(method.to_s.downcase)
   end
   
   def browse_params
-    params.permit(:sortBy)
+    params.permit(:sort)
   end
 end

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -7,11 +7,21 @@ module ListResources
   # Set up the variables we'll need for constructing a Browse page. This method has the option to
   # include the request parameters in case we need specialized parameters for a particular kind of model.
   def set_up_browse(params = browse_params)
-    sort_param = params[:sort]
     # If the user requested a valid sort method, use that. Otherwise, use the default method.
+    sort_param = params[:sort]
     @sort_method = is_valid_sort_method(sort_param) ? sort_param : DEFAULT_SORT
-    # Decide for the user whether to apply the sort method in ascending or descending order.
-    @sort_direction = @sort_method == 'updated_at' ? 'DESC' : 'ASC'
+    
+    # If the user requested a valid sort direction, use that.
+    order_param = params[:sort_direction]
+    if is_valid_sort_direction(order_param)
+      @sort_direction = order_param
+    # If the user didn't specify and the sort method is "updated_at", use descending order (most recent first).
+    elsif @sort_method == 'updated_at'
+      @sort_direction = 'DESC'
+    # Otherwise, use ascending order.
+    else
+      @sort_direction = 'ASC'
+    end
   end
   
   def sort_string
@@ -20,13 +30,18 @@ module ListResources
   
   # Test a requested sort method string against the methods we are prepared to accept. Returns true ONLY 
   # if the request parameter is provided and its lower-cased value matches one of the approved strings.
-  def is_valid_sort_method(method = browse_params[:sort])
+  def is_valid_sort_method(sort_method = browse_params[:sort])
     allowed_methods = %w(title updated_at)
-    !method.blank? && allowed_methods.include?(method.to_s.downcase)
+    !sort_method.blank? && allowed_methods.include?(sort_method.to_s.downcase)
   end
   
-  # For requests to a Browse page, permit only the sort parameter.
+  def is_valid_sort_direction(direction = browse_params[:sort_direction])
+    allowed_order = %w(desc asc)
+    !direction.blank? && allowed_order.include?(direction.to_s.downcase)
+  end
+  
+  # For requests to a Browse page, permit only the sorting parameters.
   def browse_params
-    params.permit(:sort)
+    params.permit(:sort, :sort_direction)
   end
 end

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -1,0 +1,11 @@
+module ListResources
+  extend ActiveSupport::Concern
+  
+  #def is_valid_sort_method
+    
+  #end
+  
+  def browse_params
+    params.permit(:sortBy)
+  end
+end

--- a/app/controllers/concerns/list_resources.rb
+++ b/app/controllers/concerns/list_resources.rb
@@ -27,7 +27,7 @@ module ListResources
   # Test a requested sort method string against the methods we are prepared to accept. Returns true ONLY 
   # if the request parameter is provided and its lower-cased value matches one of the approved strings.
   def is_valid_sort_method(sort_method = browse_params[:sort])
-    allowed_methods = %w(title updated_at)
+    allowed_methods = %w(created_at title updated_at)
     sort_method.present? && allowed_methods.include?(sort_method.to_s.downcase)
   end
   

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -2,6 +2,8 @@
 module Sortable
   extend ActiveSupport::Concern
   
+  private
+  
   SORT_OPTIONS = [
     ["date created", 'created_at'], 
     ["date updated", 'updated_at'], 
@@ -17,21 +19,28 @@ module Sortable
       @sort_options.concat(add_sort_options)
     end
     
-    # If the user requested a valid sort method, use that. Otherwise, use the default method.
-    sort_param = browse_params[:sort]
-    @sort_method = is_valid_sort_method(sort_param) ? sort_param : DEFAULT_SORT
-    
-    # If the user requested a valid sort direction, use that.
-    order_param = browse_params[:sort_direction]
-    @sort_direction = 
-      is_valid_sort_direction(order_param) ? order_param.to_s.upcase :
+    @sort_method = sort_method
+    @sort_direction = sort_direction
+  end
+  
+  # Choose a sort order direction.
+  def sort_direction(order_param = browse_params[:sort_direction])
+    # If the user requested a valid sort direction, use the uppercased value.
+    is_valid_sort_direction(order_param) ? order_param.to_s.upcase
       # If there isn't a given sort order but the method is "updated_at", sort the newest first.
-      # Otherwise, use ascending order.
-      @sort_method == 'updated_at' ? 'DESC' : 'ASC'
+      : @sort_method == 'updated_at' ? 'DESC'
+        # Otherwise, use ascending order.
+        : 'ASC'
+  end
+  
+  # Choose a sort method.
+  def sort_method(sort_param = browse_params[:sort])
+    # If the user requested a valid sort method, use that. Otherwise, use the default method.
+    is_valid_sort_method(sort_param) ? sort_param : DEFAULT_SORT
   end
   
   def sort_string
-    @sort_method+" "+@sort_direction
+    sort_method+" "+sort_direction
   end
   
   def allowed_sort_methods

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -1,5 +1,5 @@
-# Methods common to the Browse pages (and possibly Search)
-module ListResources
+# Methods common to pages that list sorted resources (Browse, Search)
+module Sortable
   extend ActiveSupport::Concern
   
   SORT_OPTIONS = [

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,14 +11,10 @@ class ProjectsController < ApplicationController
   # self.search_params_logic += [:add_access_controls_to_solr_params]
   
   def browse
-    # Check for a sort request parameter.
-    sortParam = browse_params[:sort]
-    # If a sort method is requested and is an allowed value, we use that. Otherwise, fall back on the 
-    # updated timestamp.
-    @sortMethod = is_valid_sort_method(sortParam) ? sortParam : 'updated_at'
-    # Decide for the user whether to apply the sort method in ascending or descending order.
-    sortDirection = @sortMethod == 'updated_at' ? 'DESC' : 'ASC'
-    @projects = Project.publicly_visible.includes(:collections, :core_files).order(@sortMethod+" "+sortDirection)
+    # The setup method defines @sort_method and @sort_direction for ListResource's sort_string() and the
+    # Browse views.
+    set_up_browse
+    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sort_string)
     render 'browse'
   end
   

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,7 +14,7 @@ class ProjectsController < ApplicationController
     # The setup method defines @sort_method and @sort_direction for ListResource's sort_string() and the
     # Browse views.
     set_up_browse
-    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sort_string)
+    @projects = Project.publicly_visible.includes(:collections, :core_files, :project_members).order(sort_string)
     render 'browse'
   end
   

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,7 +12,7 @@ class ProjectsController < ApplicationController
   
   def browse
     # Check for a sortBy request parameter.
-    sortParam = browse_params[:sortBy]
+    sortParam = browse_params[:sort]
     # If a sortBy method is requested and is an allowed value, we use that. Otherwise, fall back on the 
     # updated timestamp.
     sortMethod = is_valid_sort_method(sortParam) ? sortParam : 'updated_at'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   include ApiAccessible
-  include ListResources
+  include Sortable
 
   # figure out why this controller doesn't inherit from CatalogController the way CoreFilesController does
 
@@ -11,8 +11,8 @@ class ProjectsController < ApplicationController
   # self.search_params_logic += [:add_access_controls_to_solr_params]
   
   def browse
-    # The setup method defines @sort_method and @sort_direction for ListResource's sort_string() and the
-    # Browse views. To the default sort methods we add the sort method "total_tei".
+    # The setup method defines @sort_method and @sort_direction for Sortable's sort_string() and the
+    # Browse views. The sort method "total_tei" is added to the default sort methods.
     set_sorting([["number of TEI documents", 'total_tei']])
     @projects = Project.publicly_visible.includes(:collections, :core_files, :project_members)
     @projects = @sort_method == 'total_tei' ? @projects.sort_by { |p| p.core_files.count } : @projects.order(sort_string)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   include ApiAccessible
+  include ListResources
 
   # figure out why this controller doesn't inherit from CatalogController the way CoreFilesController does
 
@@ -10,7 +11,8 @@ class ProjectsController < ApplicationController
   # self.search_params_logic += [:add_access_controls_to_solr_params]
   
   def browse
-    @projects = Project.publicly_visible.includes(:collections, :core_files)
+    sortMethod = browse_params[:sortBy]
+    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sortMethod)
     render 'browse'
   end
   
@@ -100,35 +102,35 @@ class ProjectsController < ApplicationController
 
   protected
 
-  def can_edit?
-    project = Project.find(params[:id])
-    can? :manage, project
-  end
+    def can_edit?
+      project = Project.find(params[:id])
+      can? :manage, project
+    end
 
-  def can_read?
-    project = Project.find(params[:id])
-    can? :read, project
-  end
+    def can_read?
+      project = Project.find(params[:id])
+      can? :read, project
+    end
 
   private
 
-  def project_params
-    params
-      .require(:project)
-      .permit(
-        :description,
-        :image_file,
-        :title,
-        :is_public?,
-        :institution
-      )
-  end
+    def project_params
+      params
+        .require(:project)
+        .permit(
+          :description,
+          :image_file,
+          :title,
+          :is_public?,
+          :institution
+        )
+    end
 
-  def child_params
-    params.require(:project).permit(
-      :contributors => [],
-      :collaborators => [],
-      :owner => []
-    )
-  end
+    def child_params
+      params.require(:project).permit(
+        :contributors => [],
+        :collaborators => [],
+        :owner => []
+      )
+    end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -15,7 +15,18 @@ class ProjectsController < ApplicationController
     # Browse views. The sort method "total_tei" is added to the default sort methods.
     set_sorting([["number of TEI documents", 'total_tei']])
     @projects = Project.publicly_visible.includes(:collections, :core_files, :project_members)
-    @projects = @sort_method == 'total_tei' ? @projects.sort_by { |p| p.core_files.count } : @projects.order(sort_string)
+    # TODO: The use of `sort_by` below requires all Projects and Core Files to be loaded into memory —
+    #   it won't scale. We need a simple, fast SQL or Solr query, which suggests that it might be useful 
+    #   to store the count of CoreFiles associated with Projects (and Collections), and keep it up to
+    #   date as CoreFiles are added or removed.
+    if @sort_method == 'total_tei'
+      @projects = @projects.sort_by { |p| p.core_files.publicly_visible.count }
+      if @sort_direction == 'DESC'
+        @projects = @projects.reverse
+      end
+    else
+      @projects = @projects.order(sort_string)
+    end
     render 'browse'
   end
   

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,8 +11,14 @@ class ProjectsController < ApplicationController
   # self.search_params_logic += [:add_access_controls_to_solr_params]
   
   def browse
-    sortMethod = browse_params[:sortBy]
-    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sortMethod)
+    # Check for a sortBy request parameter.
+    sortParam = browse_params[:sortBy]
+    # If a sortBy method is requested and is an allowed value, we use that. Otherwise, fall back on the 
+    # updated timestamp.
+    sortMethod = is_valid_sort_method(sortParam) ? sortParam : 'updated_at'
+    # Decide for the user whether to apply the sort method in ascending or descending order.
+    sortDirection = sortMethod == 'updated_at' ? 'DESC' : 'ASC'
+    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sortMethod+" "+sortDirection)
     render 'browse'
   end
   

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,9 +12,10 @@ class ProjectsController < ApplicationController
   
   def browse
     # The setup method defines @sort_method and @sort_direction for ListResource's sort_string() and the
-    # Browse views.
-    set_up_browse
-    @projects = Project.publicly_visible.includes(:collections, :core_files, :project_members).order(sort_string)
+    # Browse views. To the default sort methods we add the sort method "total_tei".
+    set_sorting([["number of TEI documents", 'total_tei']])
+    @projects = Project.publicly_visible.includes(:collections, :core_files, :project_members)
+    @projects = @sort_method == 'total_tei' ? @projects.sort_by { |p| p.core_files.count } : @projects.order(sort_string)
     render 'browse'
   end
   

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,14 +11,14 @@ class ProjectsController < ApplicationController
   # self.search_params_logic += [:add_access_controls_to_solr_params]
   
   def browse
-    # Check for a sortBy request parameter.
+    # Check for a sort request parameter.
     sortParam = browse_params[:sort]
-    # If a sortBy method is requested and is an allowed value, we use that. Otherwise, fall back on the 
+    # If a sort method is requested and is an allowed value, we use that. Otherwise, fall back on the 
     # updated timestamp.
-    sortMethod = is_valid_sort_method(sortParam) ? sortParam : 'updated_at'
+    @sortMethod = is_valid_sort_method(sortParam) ? sortParam : 'updated_at'
     # Decide for the user whether to apply the sort method in ascending or descending order.
-    sortDirection = sortMethod == 'updated_at' ? 'DESC' : 'ASC'
-    @projects = Project.publicly_visible.includes(:collections, :core_files).order(sortMethod+" "+sortDirection)
+    sortDirection = @sortMethod == 'updated_at' ? 'DESC' : 'ASC'
+    @projects = Project.publicly_visible.includes(:collections, :core_files).order(@sortMethod+" "+sortDirection)
     render 'browse'
   end
   

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -169,4 +169,10 @@ class Collection < ApplicationRecord
       end
     end
   end
+  
+  ###  SCOPES  ###
+
+  public
+
+  scope :publicly_visible, -> { where(is_public: true) }
 end

--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -236,4 +236,11 @@ class CoreFile < ApplicationRecord
   #     self.drupal_access = 'private'
   #   end
   # end
+  
+  
+  ###  SCOPES  ###
+
+  public
+
+  scope :publicly_visible, -> { where(is_public: true) }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,6 +91,18 @@ class Project < ApplicationRecord
   def clean_edit_users
     return self.edit_users.keep_if{ |k| k != "" }
   end
+  
+  
+  ###  SCOPES  ###
+
+  public
+
+  scope :publicly_visible, -> { where(is_public: true) }
+
+  #scope :with_info_for_description, lambda {
+  #  select(:id, :title).includes(:collections, :core_files)
+  #}
+
 end
 
 #legacy code that needs review
@@ -199,18 +211,4 @@ end
 #   return members_with_roles
 # end
 
-
-###  SCOPES  ###
-
-public
-
-# TODO: Figure out why `scope` is undefined
-#scope :publicly_visible, -> { where(is_public: true) }
-def publicly_visible
-  where(is_public: true)
-end
-
-#scope :with_info_for_description, lambda {
-#  select(:id, :title).includes(:collections, :core_files)
-#}
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-  <title><%= render_page_title %></title>
+  <title><%= yield :page_name || "TAPAS Project" %></title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- TAPAS uses the "Lato" font from Google: https://fonts.google.com/specimen/Lato -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-  <title><%= yield :page_name || "TAPAS Project" %></title>
+  <title><%= content_for(:page_name) || "TAPAS Project" %></title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- TAPAS uses the "Lato" font from Google: https://fonts.google.com/specimen/Lato -->

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -38,9 +38,9 @@
           <!-- For each owner, list their name with a comma afterward. The last name in the array 
             doesn't get a comma. -->
           <% owners.each_with_index do |name, index| %>
-            <% is_last_name = index == (owners.length - 1) %>
+            <% is_final_name = index == (owners.length - 1) %>
             <li>
-              <%= name + (is_last_name ? '' : ',') %>
+              <%= name + (is_final_name ? '' : ',') %>
             </li>
           <% end %>
         </ul>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -39,11 +39,11 @@
     <% end -%>
     <dt class="col-md-3">Number of collections</dt>
       <dd class="col-md-9">
-        <%= item.collections.count %>
+        <%= item.collections.publicly_visible.count %>
       </dd>
     <dt class="col-md-3">Number of documents</dt>
       <dd class="col-md-9">
-        <%= item.core_files.count %>
+        <%= item.core_files.publicly_visible.count %>
       </dd>
   <% end -%>
 </li>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -18,6 +18,10 @@
     </span>
   </span>
   <%= tag.dl(id: collapse_id, class: ['tapas-container-content', 'row', 'collapse']) do -%>
+    <dt class="col-md-3">Created at</dt>
+      <dd class="col-md-9">
+        <%= item.created_at %>
+      </dd>
     <dt class="col-md-3">Last updated</dt>
       <dd class="col-md-9">
         <%= item.updated_at %>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -26,10 +26,24 @@
       <dd class="col-md-9">
         <%= item.description %>
       </dd>
+    <!-- NOTE: The functional spec currently (2025-10-15) implies that there is only ever one project 
+      owner. There is an issue open to refine and confirm project membership roles: 
+      https://github.com/NEU-DSG/tapas_rails/issues/111 . Until this is resolved and the dummy data 
+      script is updated, the only way to test the plural form of this field is to manually add 1+ owner 
+      to a project, or temporarily change the dummy data script to do so programmatically. -->
     <% owners = item.owner.map { |user| user.name } %>
     <dt class="col-md-3">Project administrator<%= owners.length > 1 ? 's' : '' %></dt>
       <dd class="col-md-9">
-        <%= owners.join(", ") %>
+        <ul class="inline-list">
+          <!-- For each owner, list their name with a comma afterward. The last name in the array 
+            doesn't get a comma. -->
+          <% owners.each_with_index do |name, index| %>
+            <% is_last_name = index == (owners.length - 1) %>
+            <li>
+              <%= name + (is_last_name ? '' : ',') %>
+            </li>
+          <% end %>
+        </ul>
       </dd>
     <% if item.institution %>
       <dt class="col-md-3">Institution</dt>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -26,9 +26,17 @@
       <dd class="col-md-9">
         <%= item.description %>
       </dd>
-    <!--<dt class="col-md-3">Project administrator</dt>
-      <dd class="col-md-9"> </dd>
-      <dd class="offset-md-3 col-md-9"> </dd>-->
+    <% @owners = item.owner().map { |user| user.name } %>
+    <dt class="col-md-3">Project administrator<%= @owners.length > 1 ? 's' : '' %></dt>
+      <dd class="col-md-9">
+        <%= @owners.join(", ") %>
+      </dd>
+    <% if item.institution %>
+      <dt class="col-md-3">Institution</dt>
+        <dd class="col-md-9">
+          <%= item.institution %>
+        </dd>
+    <% end -%>
     <dt class="col-md-3">Number of collections</dt>
       <dd class="col-md-9">
         <%= item.collections.count %>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -26,10 +26,10 @@
       <dd class="col-md-9">
         <%= item.description %>
       </dd>
-    <% @owners = item.owner().map { |user| user.name } %>
-    <dt class="col-md-3">Project administrator<%= @owners.length > 1 ? 's' : '' %></dt>
+    <% owners = item.owner.map { |user| user.name } %>
+    <dt class="col-md-3">Project administrator<%= owners.length > 1 ? 's' : '' %></dt>
       <dd class="col-md-9">
-        <%= @owners.join(", ") %>
+        <%= owners.join(", ") %>
       </dd>
     <% if item.institution %>
       <dt class="col-md-3">Institution</dt>

--- a/app/views/projects/_browse_container.html.erb
+++ b/app/views/projects/_browse_container.html.erb
@@ -20,21 +20,16 @@
   <%= tag.dl(id: collapse_id, class: ['tapas-container-content', 'row', 'collapse']) do -%>
     <dt class="col-md-3">Created at</dt>
       <dd class="col-md-9">
-        <%= item.created_at %>
+        <%= item.created_at.strftime('%Y-%m-%d') %>
       </dd>
     <dt class="col-md-3">Last updated</dt>
       <dd class="col-md-9">
-        <%= item.updated_at %>
+        <%= item.updated_at.strftime('%Y-%m-%d') %>
       </dd>
     <dt class="col-md-3">Description</dt>
       <dd class="col-md-9">
         <%= item.description %>
       </dd>
-    <!-- NOTE: The functional spec currently (2025-10-15) implies that there is only ever one project 
-      owner. There is an issue open to refine and confirm project membership roles: 
-      https://github.com/NEU-DSG/tapas_rails/issues/111 . Until this is resolved and the dummy data 
-      script is updated, the only way to test the plural form of this field is to manually add 1+ owner 
-      to a project, or temporarily change the dummy data script to do so programmatically. -->
     <% owners = item.owner.map { |user| user.name } %>
     <dt class="col-md-3">Project administrator<%= owners.length > 1 ? 's' : '' %></dt>
       <dd class="col-md-9">

--- a/app/views/projects/browse.html.erb
+++ b/app/views/projects/browse.html.erb
@@ -1,6 +1,4 @@
-<%= content_for :heading do %>
-  Browse Projects
-<% end %>
+<%- content_for(:page_name, "Browse Projects") %>
 
 <%= content_for :containers do %>
   <!-- A text description for the collapsible toggle is available on large enough screens. -->

--- a/app/views/projects/browse.html.erb
+++ b/app/views/projects/browse.html.erb
@@ -1,4 +1,6 @@
-<h1>Browse Projects</h1>
+<%= content_for :heading do %>
+  Browse Projects
+<% end %>
 
 <%= content_for :containers do %>
   <!-- A text description for the collapsible toggle is available on large enough screens. -->

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -36,9 +36,9 @@
       </div>
       <div>
         <label for="browse-sort-direction">Order</label>
-        <select id="browse-sort-direction" name="sort-direction"
+        <select id="browse-sort-direction" name="sort_direction"
            class="form-select form-select-sm">
-          <%= options_for_select([['ascending', 'asc'], ["descending", 'desc']], @sort_direction || 'asc') %>
+          <%= options_for_select([['ascending', 'ASC'], ['descending', 'DESC']], @sort_direction || 'ASC') %>
         </select>
       </div>
       <!-- TODO: results per page -> pagination -->

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -4,8 +4,9 @@
       <form class="sort-controls">
         <label for="browse-sort">Sort</label>
         <select id="browse-sort" name="sort" class="form-select form-select-sm">
-          <option value="title">alphabetically</option>
-          <option value="updated_at" selected="selected">last updated</option>
+          <!-- Options for the sort method: by title, or by the date last updated. The <option> which 
+            corresponds to the current sort method (or "updated_at" if not set) is selected by default. -->
+          <%= options_for_select([['alphabetically', 'title'], ["last updated", 'updated_at']], @sortMethod || 'updated_at') %>
         </select>
         <input type="submit" value="OK" class="btn btn-outline-primary btn-sm" />
       </form>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -4,8 +4,8 @@
       <form class="sort-controls">
         <label for="browse-sort">Sort</label>
         <select id="browse-sort" name="sortBy" class="form-select form-select-sm">
-          <option value="name">alphabetically</option>
-          <option value="updated" selected="selected">last updated</option>
+          <option value="title">alphabetically</option>
+          <option value="updated_at" selected="selected">last updated</option>
         </select>
         <input type="submit" value="OK" class="btn btn-outline-primary btn-sm" />
       </form>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -1,22 +1,68 @@
 <!-- HTML structure encompassing a list of resources for browsing. -->
-<nav>
-  <ul class="btn-list" aria-label="Section controls">
-    <li>
-      <form class="sort-controls">
+<div class="browse-content">
+  <h1><%= yield :heading %></h1>
+  
+  <!-- TODO: add content for pagination info -->
+  <p class="pagination-summary"></p>
+  
+  <div class="flex-spaced">
+    <!-- Upper pagination nav -->
+    <nav class="pagination-container" aria-label="Projects">
+      <!-- TODO -->
+    </nav>
+    
+    <!-- Disclosure toggles -->
+    <ul class="btn-list" aria-label="Section controls">
+      <li>
+        <button class="btn btn-sm btn-primary control-expand">Expand all 
+          <span class="visually-hidden">disclosures</span></button>
+      </li>
+      <li>
+        <button class="btn btn-sm btn-primary control-collapse">Collapse all 
+          <span class="visually-hidden">disclosures</span></button>
+      </li>
+    </ul>
+  </div>
+  
+  <aside class="sidebar">
+    <form class="sort-controls">
+      <div>
         <label for="browse-sort">Sort</label>
         <select id="browse-sort" name="sort" class="form-select form-select-sm">
           <!-- Options for the sort method: by title, or by the date last updated. The <option> which 
             corresponds to the current sort method (or "updated_at" if not set) is selected by default. -->
-          <%= options_for_select([['alphabetically', 'title'], ["last updated", 'updated_at']], @sort_method || 'updated_at') %>
+          <%= options_for_select([["date updated", 'updated_at'], ['title', 'title']], @sort_method || 'updated_at') %>
         </select>
-        <input type="submit" value="OK" class="btn btn-outline-primary btn-sm" />
-      </form>
-    </li>
-    <li><button class="btn btn-sm btn-primary control-expand">Expand all</button></li>
-    <li><button class="btn btn-sm btn-primary control-collapse">Collapse all</button></li>
+      </div>
+      <div>
+        <label for="browse-sort-direction">Order</label>
+        <select id="browse-sort-direction" name="sort-direction"
+           class="form-select form-select-sm">
+          <%= options_for_select([['ascending', 'asc'], ["descending", 'desc']], @sort_direction || 'asc') %>
+        </select>
+      </div>
+      <!-- TODO: results per page -> pagination -->
+      <!--<div>
+        <label for="page-limit-select">Results per page</label>
+        <select id="page-limit-select" name="limit" class="form-select form-select-sm">
+          <option value="25" selected="selected">25</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </div>-->
+      <div class="flex-grow-1 justify-content-end">
+        <input type="submit" value="Apply" class="btn btn-outline-primary btn-sm" />
+      </div>
+    </form>
+  </aside>
+  
+  <!-- List of resources for the Browse page -->
+  <ul class="container-sequence">
+    <%= yield :containers %>
   </ul>
-</nav>
-
-<ul class="container-sequence">
-  <%= yield :containers %>
-</ul>
+  
+  <!-- Lower pagination nav -->
+  <nav class="pagination-container" aria-label="Page">
+    <!-- TODO -->
+  </nav>
+</div>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -1,6 +1,6 @@
 <!-- HTML structure encompassing a list of resources for browsing. -->
 <div class="browse-content">
-  <h1><%= yield :heading %></h1>
+  <h1><%= yield :page_name %></h1>
   
   <!-- TODO: add content for pagination info -->
   <p class="pagination-summary"></p>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -31,7 +31,7 @@
         <select id="browse-sort" name="sort" class="form-select form-select-sm">
           <!-- Options for the sort method: by title, or by the date last updated. The <option> which 
             corresponds to the current sort method (or "updated_at" if not set) is selected by default. -->
-          <%= options_for_select([["date updated", 'updated_at'], ['title', 'title']], @sort_method || 'updated_at') %>
+          <%= options_for_select([["date created", 'created_at'], ["date updated", 'updated_at'], ['title', 'title']], @sort_method || 'updated_at') %>
         </select>
       </div>
       <div>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -3,7 +3,7 @@
     <li>
       <form class="sort-controls">
         <label for="browse-sort">Sort</label>
-        <select id="browse-sort" name="sort-by" class="form-select form-select-sm">
+        <select id="browse-sort" name="sortBy" class="form-select form-select-sm">
           <option value="name">alphabetically</option>
           <option value="updated" selected="selected">last updated</option>
         </select>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -31,14 +31,14 @@
         <select id="browse-sort" name="sort" class="form-select form-select-sm">
           <!-- Options for the sort method: by title, or by the date last updated. The <option> which 
             corresponds to the current sort method (or "updated_at" if not set) is selected by default. -->
-          <%= options_for_select([["date created", 'created_at'], ["date updated", 'updated_at'], ['title', 'title']], @sort_method || 'updated_at') %>
+          <%= options_for_select(@sort_options, @sort_method) %>
         </select>
       </div>
       <div>
         <label for="browse-sort-direction">Order</label>
         <select id="browse-sort-direction" name="sort_direction"
            class="form-select form-select-sm">
-          <%= options_for_select([['ascending', 'ASC'], ['descending', 'DESC']], @sort_direction || 'ASC') %>
+          <%= options_for_select([['ascending', 'ASC'], ['descending', 'DESC']], @sort_direction) %>
         </select>
       </div>
       <!-- TODO: results per page -> pagination -->

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -3,7 +3,7 @@
     <li>
       <form class="sort-controls">
         <label for="browse-sort">Sort</label>
-        <select id="browse-sort" name="sortBy" class="form-select form-select-sm">
+        <select id="browse-sort" name="sort" class="form-select form-select-sm">
           <option value="title">alphabetically</option>
           <option value="updated_at" selected="selected">last updated</option>
         </select>

--- a/app/views/shared/_browse_page.html.erb
+++ b/app/views/shared/_browse_page.html.erb
@@ -1,3 +1,4 @@
+<!-- HTML structure encompassing a list of resources for browsing. -->
 <nav>
   <ul class="btn-list" aria-label="Section controls">
     <li>
@@ -6,7 +7,7 @@
         <select id="browse-sort" name="sort" class="form-select form-select-sm">
           <!-- Options for the sort method: by title, or by the date last updated. The <option> which 
             corresponds to the current sort method (or "updated_at" if not set) is selected by default. -->
-          <%= options_for_select([['alphabetically', 'title'], ["last updated", 'updated_at']], @sortMethod || 'updated_at') %>
+          <%= options_for_select([['alphabetically', 'title'], ["last updated", 'updated_at']], @sort_method || 'updated_at') %>
         </select>
         <input type="submit" value="OK" class="btn btn-outline-primary btn-sm" />
       </form>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -67,18 +67,18 @@
           </ul>
         </li>
         <% if current_user %>
-        <li class="nav-item dropdown">
-          <button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
-            data-bs-toggle="dropdown">Create</button>
-          <ul class="dropdown-menu">
-            <li class="nav-item">
-              <a href="/add/record" class="dropdown-item">TEI Record</a></li>
-            <li class="nav-item">
-              <a href="/add/collection" class="dropdown-item">Collection</a></li>
-            <li class="nav-item">
-              <a href="/add/project" class="dropdown-item">Project</a></li>
-          </ul>
-        </li>
+          <li class="nav-item dropdown">
+            <button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
+              data-bs-toggle="dropdown">Create</button>
+            <ul class="dropdown-menu">
+              <li class="nav-item">
+                <a href="/add/record" class="dropdown-item">TEI Record</a></li>
+              <li class="nav-item">
+                <a href="/add/collection" class="dropdown-item">Collection</a></li>
+              <li class="nav-item">
+                <a href="/add/project" class="dropdown-item">Project</a></li>
+            </ul>
+          </li>
         <% end %>
       </ul>
       <!-- User account and authentication -->

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <!-- TAPAS site navigation -->
-    <nav id="header-nav" class="collapse navbar-collapse">
+    <nav id="header-nav" class="collapse navbar-collapse" aria-label="Site">
       <ul class="navbar-nav">
         <li class="nav-item dropdown">
           <button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
@@ -52,18 +52,22 @@
               <a href="/faq" class="dropdown-item">Frequently Asked Questions</a></li>
           </ul>
         </li>
-        <li class="nav-item">
-          <a href="/browse" class="nav-link">Browse</a>
-          <!--<button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
-            data-bs-toggle="dropdown">Discover</button>
+        <li class="nav-item dropdown">
+          <button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
+            data-bs-toggle="dropdown">Browse</button>
           <ul class="dropdown-menu">
-            <li><!-\- landing page -\->
-              <a href="/browse" class="dropdown-item">Browse</a></li>
-            <li>
-              <a href="/search" class="dropdown-item">Search</a></li>
-          </ul>-->
+            <li class="nav-item">
+              <a href="/browse/records" class="dropdown-item">TEI Records</a></li>
+            <li class="nav-item">
+              <a href="/browse/collections" class="dropdown-item">Collections</a></li>
+            <li class="nav-item">
+              <a href="/browse/projects" class="dropdown-item">Projects</a></li>
+            <!--<li class="nav-item">
+              <a href="/search" class="dropdown-item">Search TAPAS</a></li>-->
+          </ul>
         </li>
-        <li class="nav-item dropdown" data-tapas-registered-user="true">
+        <% if current_user %>
+        <li class="nav-item dropdown">
           <button type="button" class="nav-link dropdown-toggle" aria-expanded="false" 
             data-bs-toggle="dropdown">Create</button>
           <ul class="dropdown-menu">
@@ -75,6 +79,7 @@
               <a href="/add/project" class="dropdown-item">Project</a></li>
           </ul>
         </li>
+        <% end %>
       </ul>
       <!-- User account and authentication -->
       <%= render 'shared/user_header_nav' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -72,11 +72,11 @@
               data-bs-toggle="dropdown">Create</button>
             <ul class="dropdown-menu">
               <li class="nav-item">
-                <a href="/add/record" class="dropdown-item">TEI Record</a></li>
+                <a href="/core_files/new" class="dropdown-item">TEI Record</a></li>
               <li class="nav-item">
-                <a href="/add/collection" class="dropdown-item">Collection</a></li>
+                <a href="/collections/new" class="dropdown-item">Collection</a></li>
               <li class="nav-item">
-                <a href="/add/project" class="dropdown-item">Project</a></li>
+                <a href="/projects/new" class="dropdown-item">Project</a></li>
             </ul>
           </li>
         <% end %>

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -325,8 +325,8 @@ namespace :dummy_data_generator do
     if Project.count == num_projects + older_projects
       puts "#{ num_projects.to_s } Projects created."
     else
-      numNew = Project.count - older_projects
-      puts "WARNING: #{numNew} projects created, expected #{num_projects + older_projects}"
+      num_new = Project.count - older_projects
+      puts "WARNING: #{num_new} projects created, expected #{num_projects + older_projects}"
     end
   end
 
@@ -391,14 +391,23 @@ namespace :dummy_data_generator do
 
   desc "creates non-admin users"
   task :non_admin_users => :environment do
-    275.times do
+    # Check the number of Users we had before creating new ones
+    older_users = User.count
+    num_new_users = 275
+    
+    num_new_users.times do
       user = User.create(name: Faker::Name.unique.name,
                   email: Faker::Internet.email,
                   bio: Faker::Lorem.paragraph,
                   password: Faker::Internet.password
       )
-
-      puts "Non-admin user #{user.id} has been created." unless user.nil?
+    end
+    
+    if User.count == older_users + num_new_users
+      puts "Created #{num_new_users} regular TAPAS users"
+    else
+      num_new = User.count - older_projects
+      puts "WARNING: #{num_new} users created, expected #{num_new_users + older_users}"
     end
   end
 

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -117,17 +117,6 @@ namespace :dummy_data_generator do
         puts (visibility ? "Public" : "Private") + 
           " collection #{collection.id}: #{collection.title} created for Project #{project.id}."
       end
-
-      #2.times do
-      #  private = Collection.create(title: Faker::Food.dish,
-      #                              description: Faker::GreekPhilosophers.quote,
-      #                              depositor_id: project_users.sample&.id,
-      #                              project_id: project.id,
-      #                              is_public: false
-      #  )
-
-      #  puts "Private collection #{private.id}: #{private.title} created for Project #{project.id}."
-      #end
     end
   end
 
@@ -157,17 +146,6 @@ namespace :dummy_data_generator do
         end
       end
       puts "Created "+ (collection.core_files.length - older_core_files).to_s + " core files within Collection #{collection.id}"
-
-      #3.times do
-      #  CoreFile.create(title: Faker::Book.title,
-      #                  description: Faker::Book.genre,
-      #                  depositor_id: collection_users.sample&.id,
-      #                  collections: [collection].compact,
-      #                  is_public: visibility,
-      #                  ography_type: ography_types.sample,
-      #                  tei_authors: Faker::Artist.name
-      #  )
-      #end
     end
   end
 

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -365,7 +365,7 @@ namespace :dummy_data_generator do
     email = ENV.fetch('DUMMY_ADMIN_EMAIL')
     
     # Check for an existing user with the dummy admin email address before creating a new user.
-    if  !User.where(email: email).exists?
+    if  User.where(email: email).empty?
       password = ENV.fetch('DUMMY_ADMIN_PASSWORD')
   
       user = User.create(name: 'Admin',

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -51,22 +51,25 @@ namespace :dummy_data_generator do
   end
 
   def create_project_members
+    # NOTE: Getting projects with no members will be much easier to do in Rails 6.1+, 
+    # e.g. `Project.where.missing(:project_members)`
     Project.all.each do |project|
       non_admin_ids = User.all.select { |u| u.admin_at.nil? }.map(&:id)
-      num_contributors = Random.rand(5)   # 0 to 5
-      num_collaborators = Random.rand(3)  # 0 to 3
+      # 2025: Commented out "contributors" because a project should only have "administrators" and "collaborators"
+      #num_contributors = Random.rand(5)   # 0 to 4
+      num_collaborators = Random.rand(6)  # 0 to 5
       num_owners = 1 + Random.rand(4)     # 1 to 4
 
       # contributors
       # has a TAPAS account and either creates or contributes to a TAPAS project
-      num_contributors.times do
-        user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
+      #num_contributors.times do
+      #  user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
-        ProjectMember.create(project_id: project.id,
-                             user_id: user_id,
-                             role: 'contributor'
-        )
-      end
+      #  ProjectMember.create(project_id: project.id,
+      #                       user_id: user_id,
+      #                       role: 'contributor'
+      #  )
+      #end
 
       # collaborator
       # has editorial access to a TAPAS project but is not the owner
@@ -207,14 +210,15 @@ namespace :dummy_data_generator do
   desc "creates projects"
   task :projects => :environment do
     # Check the number of Projects we had before creating new ones
-    current_projects = Project.count
+    older_projects = Project.count
     num_projects = 45
-    # Pick a number between 0 and 2. If the number is 2, the project is private.
-    is_private = Random.rand(3) == 2
-    # Pick a number between 0 and 3. If the number is 3, generate an institution string.
-    include_institution = Random.rand(4) == 3
     
     num_projects.times do
+      # Pick a number between 0 and 2. If the number is 2, the project is private.
+      is_private = Random.rand(3) == 2
+      # Pick a number between 0 and 3. If the number is 3, generate an institution string.
+      include_institution = Random.rand(4) == 3
+      
       Project.create(title: Faker::Company.bs,
                      description: Faker::Lorem.paragraph,
                      depositor_id: User.all.where(admin_at: nil).sample.id,
@@ -223,8 +227,8 @@ namespace :dummy_data_generator do
       )
     end
 
-    puts Project.count == num_projects + current_projects ? num_projects.to_s + ' Projects created.' 
-                                                          : '"Create Projects" task failed.'
+    puts Project.count == num_projects + older_projects ? num_projects.to_s + ' Projects created.' 
+          : '"Create Projects" task failed.'
   end
 
   desc 'creates project members'

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -206,30 +206,25 @@ namespace :dummy_data_generator do
 
   desc "creates projects"
   task :projects => :environment do
-    num_public = 40
-    num_private = 5
+    # Check the number of Projects we had before creating new ones
+    current_projects = Project.count
+    num_projects = 45
+    # Pick a number between 0 and 2. If the number is 2, the project is private.
+    is_private = Random.rand(3) == 2
+    # Pick a number between 0 and 3. If the number is 3, generate an institution string.
+    include_institution = Random.rand(4) == 3
     
-    # Make public projects
-    num_public.times do
-      Project.create(title: Faker::Company.bs,
-                     description: Faker::Lorem.paragraph,
-                     depositor_id: User.all.sample.id,
-                     # Pick a number between 0 and 3. If the number is 3, generate an institution string.
-                     institution: Random.rand(4) == 3 ? Faker::University.name : nil
-      )
-    end
-
-    # Make private projects
-    num_private.times do
+    num_projects.times do
       Project.create(title: Faker::Company.bs,
                      description: Faker::Lorem.paragraph,
                      depositor_id: User.all.where(admin_at: nil).sample.id,
-                     is_public: false,
-                     institution: Faker::University.name
+                     is_public: !is_private,
+                     institution: include_institution ? Faker::University.name : nil
       )
     end
 
-    puts Project.count == num_public + num_private ? 'All Projects created.' : '"Create Projects" task failed.'
+    puts Project.count == num_projects + current_projects ? num_projects.to_s + ' Projects created.' 
+                                                          : '"Create Projects" task failed.'
   end
 
   desc 'creates project members'

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -131,35 +131,37 @@ namespace :dummy_data_generator do
       collection_users = project.members.values.flatten.shuffle
       visibility = collection.is_public
       ography_types = CoreFile.all_ography_types
+      older_core_files = collection.core_files.length
+      num_core_files = Random.rand(51) # 0 to 50
 
-      47.times do
+      num_core_files.times do
         core_file = CoreFile.create(title: Faker::Book.title,
                         description: Faker::Book.genre,
                         depositor_id: collection_users.sample&.id,
                         collections: [collection].compact,
-                        is_public: [visibility, !visibility].sample,
+                        is_public: visibility ? [visibility, !visibility].sample : visibility,
                         tei_authors: Faker::Creature.name
         )
 
         if core_file.id.nil? || !core_file.valid?
           puts 'Create Core Files task failed.'
-        else
-          puts "Core file #{core_file.id} created within Collection #{collection.id}"
+        #else
           # TODO: revisit this for TEI files
           # record_image(core_file)
         end
       end
+      puts "Created "+ (collection.core_files.length - older_core_files).to_s + " core files within Collection #{collection.id}"
 
-      3.times do
-        CoreFile.create(title: Faker::Book.title,
-                        description: Faker::Book.genre,
-                        depositor_id: collection_users.sample&.id,
-                        collections: [collection].compact,
-                        is_public: visibility,
-                        ography_type: ography_types.sample,
-                        tei_authors: Faker::Artist.name
-        )
-      end
+      #3.times do
+      #  CoreFile.create(title: Faker::Book.title,
+      #                  description: Faker::Book.genre,
+      #                  depositor_id: collection_users.sample&.id,
+      #                  collections: [collection].compact,
+      #                  is_public: visibility,
+      #                  ography_type: ography_types.sample,
+      #                  tei_authors: Faker::Artist.name
+      #  )
+      #end
     end
   end
 

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -84,35 +84,24 @@ namespace :dummy_data_generator do
     # e.g. `Project.where.missing(:project_members)`
     Project.all.each do |project|
       non_admin_ids = User.all.select { |u| u.admin_at.nil? }.map(&:id)
-      # 2025: Commented out "contributors" because a project should only have "administrators" and "collaborators"
-      #num_contributors = Random.rand(5)   # 0 to 4
-      num_collaborators = Random.rand(6)  # 0 to 5
-      num_owners = 1                      # 1
+      num_contributors = Random.rand(5)   # 0 to 4
+      num_owners = 1 + Random.rand(3)     # 1 to 3
 
-      # contributors
-      # has a TAPAS account and either creates or contributes to a TAPAS project
-      #num_contributors.times do
-      #  user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
-
-      #  ProjectMember.create(project_id: project.id,
-      #                       user_id: user_id,
-      #                       role: 'contributor'
-      #  )
-      #end
-
-      # collaborator
-      # has editorial access to a TAPAS project but is not the owner
-      num_collaborators.times do
+      # contributor
+      # has access to a TAPAS project but is not the owner
+      # can create core files but not collections
+      num_contributors.times do
         user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
         ProjectMember.create(project_id: project.id,
                              user_id: user_id,
-                             role: 'collaborator'
+                             role: 'contributor'
         )
       end
 
       # project owners
-      # has created the project in question and has responsibility for it
+      # has full edit access for the project
+      # can create collections and core files
       num_owners.times do
         user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
@@ -128,9 +117,10 @@ namespace :dummy_data_generator do
 
   def create_collections
     Project.all.each do |project|
-      project_users = project.members.values.flatten.shuffle
+      project_owners = project.owner.flatten.shuffle
       older_collections = project.collections.length
-      num_collections = Random.rand(6) # 0 to 5
+      is_empty = Random.rand(101) >= 95  # Very low chance for a project to have 0 collections
+      num_collections = is_empty ? 0 : 1 + Random.rand(5) # 0 to 5
 
       num_collections.times do
         # If the project is public, the collection can be public or private.
@@ -138,7 +128,7 @@ namespace :dummy_data_generator do
         visibility = project.is_public ? [true, false].sample : false
         collection = Collection.create(title: Faker::Food.dish,
                                    description: Faker::GreekPhilosophers.quote,
-                                   depositor_id: project_users.sample&.id,
+                                   depositor_id: project_owners.sample&.id,
                                    project_id: project.id,
                                    is_public: visibility
         )
@@ -148,56 +138,48 @@ namespace :dummy_data_generator do
       end
     end
   end
+  
+  def create_new_core_file(collection, users, ography_type = nil)
+    project = collection.project
+    visibility = collection.is_public
+    core_file = CoreFile.create(title: Faker::Book.title,
+                    description: Faker::Book.genre,
+                    depositor_id: users.sample&.id,
+                    collections: [collection].compact,
+                    is_public: visibility ? [visibility, !visibility].sample : visibility,
+                    tei_authors: Faker::Creature.name,
+                    ography_type: ography_type
+    )
+
+    # Attach TEI file (required for non-ography files)
+    attach_tei_file(core_file)
+
+    if core_file.save
+      #puts "Core file #{core_file.id} created within Collection #{collection.id}"
+      # record_image(core_file)
+    else
+      puts "Create Core Files task failed: #{core_file.errors.full_messages.join(', ')}"
+    end
+  end
 
   def create_core_files
     Collection.all.each do |collection|
-      project = collection.project
-      collection_users = project.members.values.flatten.shuffle
-      visibility = collection.is_public
+      collection_users = collection.project.members.values.flatten.shuffle
       ography_types = CoreFile.all_ography_types
       older_core_files = collection.core_files.length
       num_core_files = Random.rand(51) # 0 to 50
+      num_ography_files = Random.rand(3) # 0 to 2
 
       num_core_files.times do
-        core_file = CoreFile.create(title: Faker::Book.title,
-                        description: Faker::Book.genre,
-                        depositor_id: collection_users.sample&.id,
-                        collections: [collection].compact,
-                        is_public: visibility ? [visibility, !visibility].sample : visibility,
-                        tei_authors: Faker::Creature.name
-        )
-
-        # Attach TEI file (required for non-ography files)
-        attach_tei_file(core_file)
-
-        if core_file.save
-          #puts "Core file #{core_file.id} created within Collection #{collection.id}"
-          # record_image(core_file)
-        else
-          puts "Create Core Files task failed: #{core_file.errors.full_messages.join(', ')}"
-        end
+        create_new_core_file(collection, collection_users)
       end
 
-      # Create 2 ography support files (don't need TEI)
-      2.times do
-        core_file = CoreFile.create(title: Faker::Book.title,
-                        description: Faker::Book.genre,
-                        depositor_id: collection_users.sample&.id,
-                        collections: [collection].compact,
-                        is_public: visibility,
-                        ography_type: ography_types.sample,
-                        tei_authors: Faker::Artist.name
-        )
-
-        if core_file.persisted?
-          puts "Ography file #{core_file.id} (#{core_file.ography_type}) created within Collection #{collection.id}"
-          sleep 0.3  # Longer delay
-        else
-          puts "Create Ography Files task failed: #{core_file.errors.full_messages.join(', ')}"
-        end
+      # Create 0 to 2 ography support files
+      num_ography_files.times do
+        create_new_core_file(collection, collection_users, ography_types.sample)
       end
       
-      puts "Created "+ (collection.core_files.length - older_core_files).to_s + " core files within Collection #{collection.id}"
+      puts "Created "+ (collection.core_files.reload.size - older_core_files).to_s + " core files within Collection #{collection.id}"
 
       # Clear connection pool after each collection
       ActiveRecord::Base.connection_pool.release_connection

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -83,6 +83,7 @@ namespace :dummy_data_generator do
     # NOTE: Getting projects with no members will be much easier to do in Rails 6.1+, 
     # e.g. `Project.where.missing(:project_members)`
     Project.all.each do |project|
+      puts "Creating users for project #{project.id}:"
       non_admin_ids = User.all.select { |u| u.admin_at.nil? }.map(&:id)
       available_users = non_admin_ids #- ProjectMember.all.map(&:user_id)
       num_contributors = Random.rand(13)   # 0 to 12
@@ -93,8 +94,8 @@ namespace :dummy_data_generator do
       # can create collections and core files
       # Start with the project depositor.
       ProjectMember.create(project_id: project.id,
-                            user_id: project.depositor_id,
-                            role: 'owner'
+                           user_id: project.depositor_id,
+                           role: 'owner'
       )
       # Remove the depositor from the array of available users.
       available_users.delete(project.depositor_id)
@@ -121,15 +122,16 @@ namespace :dummy_data_generator do
         )
       end
 
-      puts "#{project.owner.flatten.length} project owners created for #{project.__id__}"
+      puts "   #{project.owner.flatten.length} project owner(s)"
       if project.contributors
-        puts "#{project.contributors.flatten.length} project contributors created for #{project.__id__}"
+        puts "   #{project.contributors.flatten.length} project contributor(s)"
       end
     end
   end
 
   def create_collections
     Project.all.each do |project|
+      puts "Creating collections for project #{project.id}"
       project_owners = project.owner.flatten.shuffle
       older_collections = project.collections.length
       is_empty = Random.rand(101) >= 95  # Very low chance for a project to have 0 collections
@@ -146,12 +148,15 @@ namespace :dummy_data_generator do
                                    is_public: visibility
         )
 
-        puts (visibility ? "Public" : "Private") + 
-          " collection #{collection.id}: #{collection.title} created for Project #{project.id}."
+        puts "   " + (visibility ? "Public" : "Private") 
+          + " collection #{collection.id}: #{collection.title}"
       end
     end
+    
+    puts "Collection creation complete!"
   end
   
+  # Create a single new Core File
   def create_new_core_file(collection, users, ography_type = nil)
     project = collection.project
     visibility = collection.is_public
@@ -171,12 +176,13 @@ namespace :dummy_data_generator do
       #puts "Core file #{core_file.id} created within Collection #{collection.id}"
       # record_image(core_file)
     else
-      puts "Create Core Files task failed: #{core_file.errors.full_messages.join(', ')}"
+      puts "Create Core File task failed: #{core_file.errors.full_messages.join(', ')}"
     end
   end
 
   def create_core_files
     Collection.all.each do |collection|
+      puts "Creating core files for collection #{collection.id} in project #{collection.project.id}"
       collection_users = collection.project.members.values.flatten.shuffle
       ography_types = CoreFile.all_ography_types
       older_core_files = collection.core_files.length
@@ -192,7 +198,7 @@ namespace :dummy_data_generator do
         create_new_core_file(collection, collection_users, ography_types.sample)
       end
       
-      puts "Created "+ (collection.core_files.reload.size - older_core_files).to_s + " core files within Collection #{collection.id}"
+      puts "   Created "+ (collection.core_files.reload.size - older_core_files).to_s + " core files"
 
       # Clear connection pool after each collection
       ActiveRecord::Base.connection_pool.release_connection
@@ -316,8 +322,12 @@ namespace :dummy_data_generator do
       )
     end
 
-    puts Project.count == num_projects + older_projects ? num_projects.to_s + ' Projects created.' 
-          : '"Create Projects" task failed.'
+    if Project.count == num_projects + older_projects
+      puts "#{ num_projects.to_s } Projects created."
+    else
+      numNew = Project.count - older_projects
+      puts "WARNING: #{numNew} projects created, expected #{num_projects + older_projects}"
+    end
   end
 
   desc 'creates project members'

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -100,28 +100,34 @@ namespace :dummy_data_generator do
   def create_collections
     Project.all.each do |project|
       project_users = project.members.values.flatten.shuffle
+      older_collections = project.collections.length
+      num_collections = Random.rand(6) # 0 to 5
 
-      3.times do
-        public = Collection.create(title: Faker::Food.dish,
+      num_collections.times do
+        # If the project is public, the collection can be public or private.
+        # If the project is private, the new collection must be too.
+        visibility = project.is_public ? [true, false].sample : false
+        collection = Collection.create(title: Faker::Food.dish,
                                    description: Faker::GreekPhilosophers.quote,
                                    depositor_id: project_users.sample&.id,
                                    project_id: project.id,
-                                   is_public: true
+                                   is_public: visibility
         )
 
-        puts "Public collection #{public.id}: #{public.title} created for Project #{project.id}."
+        puts (visibility ? "Public" : "Private") + 
+          " collection #{collection.id}: #{collection.title} created for Project #{project.id}."
       end
 
-      2.times do
-        private = Collection.create(title: Faker::Food.dish,
-                                    description: Faker::GreekPhilosophers.quote,
-                                    depositor_id: project_users.sample&.id,
-                                    project_id: project.id,
-                                    is_public: false
-        )
+      #2.times do
+      #  private = Collection.create(title: Faker::Food.dish,
+      #                              description: Faker::GreekPhilosophers.quote,
+      #                              depositor_id: project_users.sample&.id,
+      #                              project_id: project.id,
+      #                              is_public: false
+      #  )
 
-        puts "Private collection #{private.id}: #{private.title} created for Project #{project.id}."
-      end
+      #  puts "Private collection #{private.id}: #{private.title} created for Project #{project.id}."
+      #end
     end
   end
 

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -58,7 +58,7 @@ namespace :dummy_data_generator do
       # 2025: Commented out "contributors" because a project should only have "administrators" and "collaborators"
       #num_contributors = Random.rand(5)   # 0 to 4
       num_collaborators = Random.rand(6)  # 0 to 5
-      num_owners = 1 + Random.rand(4)     # 1 to 4
+      num_owners = 1                      # 1
 
       # contributors
       # has a TAPAS account and either creates or contributes to a TAPAS project

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -360,19 +360,25 @@ namespace :dummy_data_generator do
     end
   end
 
-  desc "creates admin user"
+  desc "creates the admin user, if it doesn't exist"
   task :admin_user => :environment do
     email = ENV.fetch('DUMMY_ADMIN_EMAIL')
-    password = ENV.fetch('DUMMY_ADMIN_PASSWORD')
-
-    user = User.create(name: 'Admin',
-                email: email,
-                bio: Faker::Lorem.paragraph,
-                password: password,
-                admin_at: Time.now
-    )
-
-    puts "Admin user #{user.id} has been created." unless user.nil?
+    
+    # Check for an existing user with the dummy admin email address before creating a new user.
+    if  !User.where(email: email).exists?
+      password = ENV.fetch('DUMMY_ADMIN_PASSWORD')
+  
+      user = User.create(name: 'Admin',
+                  email: email,
+                  bio: Faker::Lorem.paragraph,
+                  password: password,
+                  admin_at: Time.now
+      )
+  
+      puts "Admin user #{user.id} has been created." unless user.nil?
+    else
+      puts "Admin user already exists."
+    end
   end
 
   desc "creates debug non-admin user"

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -53,10 +53,13 @@ namespace :dummy_data_generator do
   def create_project_members
     Project.all.each do |project|
       non_admin_ids = User.all.select { |u| u.admin_at.nil? }.map(&:id)
+      num_contributors = Random.rand(5)   # 0 to 5
+      num_collaborators = Random.rand(3)  # 0 to 3
+      num_owners = 1 + Random.rand(4)     # 1 to 4
 
       # contributors
       # has a TAPAS account and either creates or contributes to a TAPAS project
-      5.times do
+      num_contributors.times do
         user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
         ProjectMember.create(project_id: project.id,
@@ -67,7 +70,7 @@ namespace :dummy_data_generator do
 
       # collaborator
       # has editorial access to a TAPAS project but is not the owner
-      3.times do
+      num_collaborators.times do
         user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
         ProjectMember.create(project_id: project.id,
@@ -78,7 +81,7 @@ namespace :dummy_data_generator do
 
       # project owners
       # has created the project in question and has responsibility for it
-      1.times do
+      num_owners.times do
         user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
 
         ProjectMember.create(project_id: project.id,
@@ -203,15 +206,21 @@ namespace :dummy_data_generator do
 
   desc "creates projects"
   task :projects => :environment do
-    22.times do
+    num_public = 40
+    num_private = 5
+    
+    # Make public projects
+    num_public.times do
       Project.create(title: Faker::Company.bs,
                      description: Faker::Lorem.paragraph,
                      depositor_id: User.all.sample.id,
-                     institution: Faker::University.name
+                     # Pick a number between 0 and 3. If the number is 3, generate an institution string.
+                     institution: Random.rand(4) == 3 ? Faker::University.name : nil
       )
     end
 
-    3.times do
+    # Make private projects
+    num_private.times do
       Project.create(title: Faker::Company.bs,
                      description: Faker::Lorem.paragraph,
                      depositor_id: User.all.where(admin_at: nil).sample.id,
@@ -220,7 +229,7 @@ namespace :dummy_data_generator do
       )
     end
 
-    puts Project.count == 25 ? '25 Projects created.' : '"Create Projects" task failed.'
+    puts Project.count == num_public + num_private ? 'All Projects created.' : '"Create Projects" task failed.'
   end
 
   desc 'creates project members'

--- a/lib/tasks/dummy_data_generator.rake
+++ b/lib/tasks/dummy_data_generator.rake
@@ -84,26 +84,24 @@ namespace :dummy_data_generator do
     # e.g. `Project.where.missing(:project_members)`
     Project.all.each do |project|
       non_admin_ids = User.all.select { |u| u.admin_at.nil? }.map(&:id)
-      num_contributors = Random.rand(5)   # 0 to 4
-      num_owners = 1 + Random.rand(3)     # 1 to 3
-
-      # contributor
-      # has access to a TAPAS project but is not the owner
-      # can create core files but not collections
-      num_contributors.times do
-        user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
-
-        ProjectMember.create(project_id: project.id,
-                             user_id: user_id,
-                             role: 'contributor'
-        )
-      end
+      available_users = non_admin_ids #- ProjectMember.all.map(&:user_id)
+      num_contributors = Random.rand(13)   # 0 to 12
+      num_owners = Random.rand(6)   # 0 to 5, plus the depositor
 
       # project owners
       # has full edit access for the project
       # can create collections and core files
+      # Start with the project depositor.
+      ProjectMember.create(project_id: project.id,
+                            user_id: project.depositor_id,
+                            role: 'owner'
+      )
+      # Remove the depositor from the array of available users.
+      available_users.delete(project.depositor_id)
+      # Create any additional owners.
       num_owners.times do
-        user_id = (non_admin_ids - ProjectMember.all.map(&:user_id)).sample
+        user_id = available_users.sample
+        available_users.delete(user_id)
 
         ProjectMember.create(project_id: project.id,
                              user_id: user_id,
@@ -111,7 +109,22 @@ namespace :dummy_data_generator do
         )
       end
 
-      puts "#{project.members.values.flatten.count} project members created for #{project.__id__}: #{project.title}."
+      # contributor
+      # has access to a TAPAS project but is not the owner
+      # can create core files but not collections
+      num_contributors.times do
+        user_id = available_users.sample
+
+        ProjectMember.create(project_id: project.id,
+                             user_id: user_id,
+                             role: 'contributor'
+        )
+      end
+
+      puts "#{project.owner.flatten.length} project owners created for #{project.__id__}"
+      if project.contributors
+        puts "#{project.contributors.flatten.length} project contributors created for #{project.__id__}"
+      end
     end
   end
 


### PR DESCRIPTION
Closes #104. Closes #117.

This PR implements the sorting component of the revised ["Browse Projects" wireframe](https://tapasproject.org/wireframes/browse/projects.html). The interface has been updated to include control over sorting, and Rails returns the correct sequence of projects on request.


## For the reviewer

The following sort options will be available in all ["Browse" pages](https://docs.google.com/document/d/1vsD_ZJtoHAQo5-T-frH3w64Tpbmuyp4y_JaVu01Hc6w/edit?tab=t.0#heading=h.v90ktn7h1hk4): "by title, by date created, by date updated".

In addition, the "Browse Projects" page should include the ability to sort the listed projects "by number of TEI files", or, by the count of all *publicly-visible* core files within a given project.

Besides the sort method, users are also given the option to change the sort direction. On submitting the "Sort" form, a GET HTTP request is fired and the user is shown all public projects ordered by their criteria.

Note that this PR includes commits patched from [PR 2 of the wireframes repository](https://github.com/NEU-DSG/tapas-wireframes/pull/2); it isn't necessary to re-review the JS and CSS web assets.


### Supplemental updates

In order to have a varied set of projects to display and sort, I updated the `dummy_data_generator.rb` file to include randomization:

- Number of owners per project
- Number of contributors per project
- Whether a project fills out the "Institution" field or not
- Number of collections within a project
- Number of core files within a collection
- Number of 'ographies within a collection
- Public visibility of projects, collections, and core files (unless a higher tier model imposes privacy)

I also made a few changes to support generating dummy data when the database is already populated — for instance, the admin user isn't recreated if the email address in `.env` is already associated with a user. However, even with my changes, I don't recommend running the full `run_all` task except on a fresh database.


### Testing

1. Clear out your SQL database.
2. `rails dummy_data_generator:delete_indexed`
3. `rails dummy_data_generator:run_all` (This will take a while.)
4. Start Solr.
5. Start a Resque worker.
6. `rails server`
7. Open http://localhost:3000/ in your browser.
8. Test applying sort methods.
    1. Confirm the sorted sequence is in the right order based on the information available on that page.
    2. Check that the order changes depending on the sort direction.
9. Look for any projects that have 0 collections and/or 0 core files listed in their description.
    1. Click through to the project landing page, which does not take public/private into account when listing project resources. 
    2. Is the count 0 because there are private collections/core files?
    3. (You could go about this the other way around too: Use the Rails console to find a project with private collections/core files, then make sure the Browse Projects page is only taking any public ones into account.)


## Significant changes

- There are fewer `dummy_data_generator` output messages, but hopefully they provide a useful overview of the database updates being made.
    - I also increased the number of projects created to 45.
- The models for projects, collections, and core files all now have a (working!) `publicly_visible` scope.
    - Only the public projects are listed on the browse page.
    - Only the public collections and core files are tallied in the project descriptions.
    - Only public core files count toward the sort-by-TEI-documents value.
- A new controller concern, `Sortable`, is available. It is intended for use with projects, collections, and core files.
    - The project controller uses the default sort options, plus the count of public TEI files.
- I updated the site navbar to reflect Rails' route scheme.
